### PR TITLE
feat: preset hotlinks — general-purpose auto-apply URLs

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "2026.03.15.1",
+    "date": "2026-03-15",
+    "changes": [
+      {
+        "type": "paragraph",
+        "content": "Introducing preset hotlinks — generate a shareable URL for any preset that auto-applies the preset's permissions. Use it as a bookmark, a shared link, or a platform integration."
+      },
+      {
+        "type": "paragraph",
+        "content": "Mantle integration — preset hotlinks work as Mantle custom actions. Now you can request collaborator access right from your Mantle dashboard with the right permissions auto-applied for you."
+      },
+      {
+        "type": "video",
+        "content": "https://bucket.alfred.uptek.com/alfred-preset-hotlinks.mp4"
+      }
+    ]
+  },
+  {
     "version": "2026.02.26",
     "date": "2026-02-26",
     "changes": [
@@ -177,9 +195,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Fix: Improved theme detection for stores with strict security protocols."
-        ]
+        "content": ["Fix: Improved theme detection for stores with strict security protocols."]
       }
     ]
   },
@@ -197,19 +213,14 @@
       },
       {
         "type": "list",
-        "content": [
-          "View store URL, theme name, and version.",
-          "Works automatically on any Shopify store, no external API required."
-        ]
+        "content": ["View store URL, theme name, and version.", "Works automatically on any Shopify store, no external API required."]
       },
       {
         "type": "divider"
       },
       {
         "type": "list",
-        "content": [
-          "Fix: Background service worker becoming inactive interrupting shortcuts."
-        ]
+        "content": ["Fix: Background service worker becoming inactive interrupting shortcuts."]
       }
     ]
   },
@@ -292,9 +303,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "[BTS] Options page migrated to Preact for improved performance and maintainability"
-        ]
+        "content": ["[BTS] Options page migrated to Preact for improved performance and maintainability"]
       }
     ]
   },
@@ -304,9 +313,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Fix changelog page on extension update"
-        ]
+        "content": ["Fix changelog page on extension update"]
       }
     ]
   },
@@ -352,9 +359,7 @@
       },
       {
         "type": "list",
-        "content": [
-          "[BTS] Integrated a new build process to automatically generate and update the changelog."
-        ]
+        "content": ["[BTS] Integrated a new build process to automatically generate and update the changelog."]
       }
     ]
   },
@@ -368,11 +373,7 @@
       },
       {
         "type": "list",
-        "content": [
-          "Resizable primary sidebar",
-          "Resizable secondary sidebar",
-          "Resizable main preview area"
-        ]
+        "content": ["Resizable primary sidebar", "Resizable secondary sidebar", "Resizable main preview area"]
       },
       {
         "type": "video",
@@ -386,9 +387,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Add indexer for Shopify app search results"
-        ]
+        "content": ["Add indexer for Shopify app search results"]
       },
       {
         "type": "video",
@@ -399,9 +398,7 @@
       },
       {
         "type": "list",
-        "content": [
-          "[BTS] Switch to CalVer for versioning from SemVer 1.2.5"
-        ]
+        "content": ["[BTS] Switch to CalVer for versioning from SemVer 1.2.5"]
       }
     ]
   },
@@ -411,9 +408,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Open Section shortcut: Add support for main sections by appending page type to the name"
-        ]
+        "content": ["Open Section shortcut: Add support for main sections by appending page type to the name"]
       }
     ]
   },
@@ -423,9 +418,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Use `.shopify-section` to identify section wrapper for Open Section shortcut"
-        ]
+        "content": ["Use `.shopify-section` to identify section wrapper for Open Section shortcut"]
       }
     ]
   },
@@ -435,9 +428,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Add apply button to presets table actions column"
-        ]
+        "content": ["Add apply button to presets table actions column"]
       }
     ]
   },
@@ -447,9 +438,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Add shortcut to open sections in code editor"
-        ]
+        "content": ["Add shortcut to open sections in code editor"]
       },
       {
         "type": "video",
@@ -463,19 +452,14 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Add import/export for permissions presets",
-          "Add bulk delete for permissions presets"
-        ]
+        "content": ["Add import/export for permissions presets", "Add bulk delete for permissions presets"]
       },
       {
         "type": "divider"
       },
       {
         "type": "list",
-        "content": [
-          "[BTS] Fix analytics disabling in development"
-        ]
+        "content": ["[BTS] Fix analytics disabling in development"]
       }
     ]
   },
@@ -485,9 +469,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Add custom message support in permission presets"
-        ]
+        "content": ["Add custom message support in permission presets"]
       },
       {
         "type": "video",
@@ -498,9 +480,7 @@
       },
       {
         "type": "list",
-        "content": [
-          "[BTS] Add analytics tracking system for user actions and time savings"
-        ]
+        "content": ["[BTS] Add analytics tracking system for user actions and time savings"]
       }
     ]
   },
@@ -510,10 +490,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Rename extension to Alfred",
-          "Add collaborator permission presets"
-        ]
+        "content": ["Rename extension to Alfred", "Add collaborator permission presets"]
       },
       {
         "type": "video",
@@ -527,9 +504,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "New Shortcut: Clear Cart"
-        ]
+        "content": ["New Shortcut: Clear Cart"]
       }
     ]
   },
@@ -539,9 +514,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "New Shortcut: Copy Theme Preview URL"
-        ]
+        "content": ["New Shortcut: Copy Theme Preview URL"]
       },
       {
         "type": "video",
@@ -552,9 +525,7 @@
       },
       {
         "type": "list",
-        "content": [
-          "[BTS] Fix: Run main.content at document_start to avoid race condition"
-        ]
+        "content": ["[BTS] Fix: Run main.content at document_start to avoid race condition"]
       }
     ]
   },
@@ -578,9 +549,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Add context menu to copy product JSON"
-        ]
+        "content": ["Add context menu to copy product JSON"]
       }
     ]
   },
@@ -604,10 +573,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "Add context menu to open current page in admin",
-          "Add context menu to open current page in customizer"
-        ]
+        "content": ["Add context menu to open current page in admin", "Add context menu to open current page in customizer"]
       }
     ]
   },
@@ -617,10 +583,7 @@
     "changes": [
       {
         "type": "list",
-        "content": [
-          "[BTS] Add @wxt-dev/auto-icons",
-          "[BTS] Add Chrome extension icon"
-        ]
+        "content": ["[BTS] Add @wxt-dev/auto-icons", "[BTS] Add Chrome extension icon"]
       }
     ]
   }

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026.03.15.1
+@ 2026-03-15
+Introducing preset hotlinks — generate a shareable URL for any preset that auto-applies the preset's permissions. Use it as a bookmark, a shared link, or a platform integration.
+
+Mantle integration — preset hotlinks work as Mantle custom actions. Now you can request collaborator access right from your Mantle dashboard with the right permissions auto-applied for you.
+
+
+<video controls autoplay loop muted playsinline src="https://bucket.alfred.uptek.com/alfred-preset-hotlinks.mp4"></video>
+
 ## 2026.02.26
 @ 2026-02-26
 Theme data is now fetched from Alfred's CDN instead of being bundled with the extension, so theme information stays up to date automatically.

--- a/entrypoints/collaborator-access.content/App.tsx
+++ b/entrypoints/collaborator-access.content/App.tsx
@@ -1,13 +1,28 @@
 import { useEffect, useState, useRef } from 'preact/hooks';
-import { generatePresetId, getPresets, savePreset, deletePreset, exportPresets, importPresets } from './utils';
-import { formatTimeAgo } from '@/utils/helpers';
+import {
+  buildHotlinkUrl,
+  generatePresetId,
+  getPresets,
+  savePreset,
+  deletePreset,
+  exportPresets,
+  importPresets,
+  normalizePresetHandle
+} from './utils';
+import { Toast } from '@/utils/toast';
 import type { Permission, PermissionPreset } from './types';
+
+const AUTO_APPLY_PRESET_PARAM = 'alfred_preset';
+const HOTLINK_MODAL_ID = 'alfred-hotlink-modal';
 
 export default function App() {
   const [presets, setPresets] = useState<PermissionPreset[]>([]);
   const [selectedPreset, setSelectedPreset] = useState<PermissionPreset | null>(null);
   const [checkedPresets, setCheckedPresets] = useState<Set<string>>(new Set());
+  const [hotlinkUrl, setHotlinkUrl] = useState<string>('');
+  const [hotlinkHandle, setHotlinkHandle] = useState<string>('');
   const selectRef = useRef<HTMLSelectElement | null>(null);
+  const autoApplyAttemptedRef = useRef(false);
 
   useEffect(() => {
     // Load presets from storage on component mount
@@ -59,7 +74,7 @@ export default function App() {
     };
   }, [presets]);
 
-  const handleApplyPreset = async (presetToApply?: PermissionPreset) => {
+  const handleApplyPreset = async (presetToApply?: PermissionPreset, source: 'manual' | 'url_param' = 'manual') => {
     const preset = presetToApply ?? selectedPreset;
 
     if (!preset) {
@@ -100,9 +115,15 @@ export default function App() {
       }
     }
 
+    window.setTimeout(() => {
+      window.scrollTo({
+        top: Math.max(document.body.scrollHeight, document.documentElement.scrollHeight),
+        behavior: 'smooth'
+      });
+    }, 150);
+
     // Update the lastUsed timestamp
-    const updatedPreset = { ...preset, lastUsed: Date.now() };
-    await savePreset(updatedPreset);
+    const updatedPreset = await savePreset({ ...preset, lastUsed: Date.now() });
 
     // Update local state
     setPresets((prevPresets) => prevPresets.map((p) => (p.id === updatedPreset.id ? updatedPreset : p)));
@@ -118,33 +139,79 @@ export default function App() {
       action: 'apply_preset',
       metadata: {
         permissions_count: preset.permissions.length,
-        has_custom_message: !!preset.customMessage
+        has_custom_message: !!preset.customMessage,
+        source
       }
     });
+
+    Toast.success(`Applied preset "${updatedPreset.name}"`);
   };
 
+  useEffect(() => {
+    if (autoApplyAttemptedRef.current || presets.length === 0) {
+      return;
+    }
+
+    const presetNameFromUrl = new URLSearchParams(window.location.search).get(AUTO_APPLY_PRESET_PARAM);
+    if (!presetNameFromUrl?.trim()) {
+      autoApplyAttemptedRef.current = true;
+      return;
+    }
+
+    autoApplyAttemptedRef.current = true;
+
+    const matchingByHandle = presets.filter((preset) => preset.handle === normalizePresetHandle(presetNameFromUrl));
+
+    if (matchingByHandle.length === 1) {
+      void handleApplyPreset(matchingByHandle[0], 'url_param');
+      return;
+    }
+
+    const matchingPresets = presets.filter(
+      (preset) => preset.name.trim().toLowerCase() === presetNameFromUrl.trim().toLowerCase()
+    );
+
+    if (matchingPresets.length === 0) {
+      Toast.error(`Preset "${presetNameFromUrl}" not found`);
+      return;
+    }
+
+    if (matchingPresets.length > 1) {
+      Toast.error(`Multiple presets named "${presetNameFromUrl}" found`);
+      return;
+    }
+
+    void handleApplyPreset(matchingPresets[0], 'url_param');
+  }, [presets]);
+
   const handleEditPreset = async (preset: PermissionPreset) => {
-    const newName = prompt('Enter new name for the preset:', preset.name);
+    const newName = prompt(
+      'Enter new name for the preset.\n\nNote: Renaming changes the handle and breaks existing hotlinks.',
+      preset.name
+    );
 
     if (!newName || newName.trim() === preset.name) {
       return;
     }
 
-    const updatedPreset = {
-      ...preset,
-      name: newName.trim()
-    };
-
     try {
-      await savePreset(updatedPreset);
+      const updatedPreset = await savePreset({
+        ...preset,
+        name: newName.trim(),
+        handle: newName.trim()
+      });
+
       // Update local state
       setPresets(presets.map((p) => (p.id === preset.id ? updatedPreset : p)));
       // Update selected preset if it was edited
       if (selectedPreset?.id === preset.id) {
         setSelectedPreset(updatedPreset);
       }
+
+      Toast.success(`Updated preset "${updatedPreset.name}".`);
     } catch (error) {
       console.error('Failed to update preset:', error);
+      Toast.error('Failed to update preset');
     }
   };
 
@@ -158,9 +225,31 @@ export default function App() {
         if (selectedPreset?.id === presetId) {
           setSelectedPreset(null);
         }
+
+        Toast.success('Preset deleted');
       } catch (error) {
         console.error('Failed to delete preset:', error);
+        Toast.error('Failed to delete preset');
       }
+    }
+  };
+
+  const handleOpenHotlinkModal = (preset: PermissionPreset) => {
+    setHotlinkUrl(buildHotlinkUrl(preset.handle));
+    setHotlinkHandle(preset.handle);
+  };
+
+  const handleCopyHotlinkUrl = async () => {
+    if (!hotlinkUrl) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(hotlinkUrl);
+      Toast.success('URL copied');
+    } catch (error) {
+      console.error('Failed to copy hotlink URL:', error);
+      Toast.error('Failed to copy URL');
     }
   };
 
@@ -180,10 +269,10 @@ export default function App() {
       // Clear checked presets since IDs have changed
       setCheckedPresets(new Set());
 
-      alert(`Successfully imported ${count} preset${count !== 1 ? 's' : ''}.`);
+      Toast.success(`Imported ${count} preset${count !== 1 ? 's' : ''}`);
     } catch (error) {
       console.error('Import failed:', error);
-      alert('Failed to import presets. Please check the file format.');
+      Toast.error('Failed to import presets');
     }
   };
 
@@ -204,8 +293,16 @@ export default function App() {
       if (selectedPreset && presetsToDelete.includes(selectedPreset.id)) {
         setSelectedPreset(null);
       }
+
+      Toast.success(`Deleted ${presetsToDelete.length} preset${presetsToDelete.length !== 1 ? 's' : ''}`);
     }
   };
+
+  useEffect(() => {
+    const handler = () => handleSavePreset();
+    document.addEventListener('alfred:save-preset', handler);
+    return () => document.removeEventListener('alfred:save-preset', handler);
+  }, []);
 
   const handleSavePreset = async () => {
     const checkedCheckboxes = document.querySelectorAll(
@@ -243,15 +340,16 @@ export default function App() {
     const newPreset: PermissionPreset = {
       id: generatePresetId(),
       name: presetName.trim(),
+      handle: presetName.trim(),
       permissions,
       customMessage,
       createdAt: Date.now()
     };
 
     try {
-      await savePreset(newPreset);
+      const savedPreset = await savePreset(newPreset);
       // Add the new preset to the local state
-      setPresets([...presets, newPreset]);
+      setPresets((currentPresets) => [...currentPresets, savedPreset]);
 
       // Track the save preset action
       browser.runtime.sendMessage({
@@ -262,13 +360,46 @@ export default function App() {
           has_custom_message: !!customMessage
         }
       });
+
+      Toast.success(`Saved preset "${savedPreset.name}"`);
     } catch (error) {
       console.error('Failed to save preset:', error);
+      Toast.error('Failed to save preset');
     }
   };
 
   return (
     <>
+      <s-modal id={HOTLINK_MODAL_ID} heading="Preset hotlink" accessibilityLabel="Preset Hotlink Modal">
+        <s-stack gap="base">
+          <s-paragraph>
+            Auto-apply this preset using the URL parameter{' '}
+            <em>
+              <code>alfred_preset={hotlinkHandle}</code>
+            </em>{' '}
+            . Use it as a bookmark, a shared link, or a platform integration.
+          </s-paragraph>
+          <s-paragraph>
+            <em>Note: Renaming the preset changes the handle and breaks existing hotlinks.</em>
+          </s-paragraph>
+          <s-divider></s-divider>
+          <s-paragraph>
+            <strong>Mantle</strong> — Use as a Mantle custom action by pasting the following URL into the custom
+            action's URL field.
+          </s-paragraph>
+          <s-stack direction="inline" gap="small-200" alignItems="center">
+            <div style={{ flex: '1 1 auto' }}>
+              <s-text-field value={hotlinkUrl} readOnly />
+            </div>
+            <s-button variant="secondary" icon="clipboard" accessibilityLabel="Copy URL" onClick={handleCopyHotlinkUrl}>
+              Copy
+            </s-button>
+          </s-stack>
+        </s-stack>
+        <s-button slot="primary-action" variant="primary" commandFor={HOTLINK_MODAL_ID} command="--hide">
+          Close
+        </s-button>
+      </s-modal>
       <s-divider></s-divider>
       <s-box padding="large">
         <s-stack gap="base">
@@ -312,9 +443,9 @@ export default function App() {
                   )}
                 </s-table-header>
                 <s-table-header listSlot="primary">Name</s-table-header>
+                <s-table-header>Handle</s-table-header>
                 <s-table-header>Permissions</s-table-header>
                 <s-table-header>Message</s-table-header>
-                <s-table-header>Created</s-table-header>
                 <s-table-header>Actions</s-table-header>
               </s-table-header-row>
               <s-table-body>
@@ -347,6 +478,9 @@ export default function App() {
                       </s-table-cell>
                       <s-table-cell>{preset.name}</s-table-cell>
                       <s-table-cell>
+                        <code style={{ fontSize: '12px', color: 'rgb(97, 107, 117)' }}>{preset.handle}</code>
+                      </s-table-cell>
+                      <s-table-cell>
                         {preset.permissions
                           .slice(0, 2)
                           .map((p) => (p.label.length > 15 ? p.label.slice(0, 15) + '...' : p.label))
@@ -360,8 +494,8 @@ export default function App() {
                           <s-icon type="x-circle"></s-icon>
                         )}
                       </s-table-cell>
-                      <s-table-cell>{formatTimeAgo(preset.createdAt)}</s-table-cell>
                       <s-table-cell>
+                        {/* Actions */}
                         <s-stack direction="inline" gap="small-200">
                           <s-button
                             icon="check-circle-filled"
@@ -381,6 +515,15 @@ export default function App() {
                             accessibilityLabel="Delete preset"
                             onClick={() => handleDeletePreset(preset.id)}
                           />
+                          <s-divider direction="block"></s-divider>
+                          <s-button
+                            accessibilityLabel="Hotlink"
+                            icon="link"
+                            commandFor={HOTLINK_MODAL_ID}
+                            command="--show"
+                            onClick={() => handleOpenHotlinkModal(preset)}>
+                            Hotlink
+                          </s-button>
                         </s-stack>
                       </s-table-cell>
                     </s-table-row>

--- a/entrypoints/collaborator-access.content/index.tsx
+++ b/entrypoints/collaborator-access.content/index.tsx
@@ -54,6 +54,21 @@ export default defineContentScript({
       }
     });
 
+    // Insert a "Save preset" proxy button before the create-new-store button
+    const createStoreBtn = await waitForElement('#create-new-store-button');
+    if (createStoreBtn) {
+      const proxyBtn = document.createElement('button');
+      proxyBtn.type = 'button';
+      proxyBtn.textContent = 'Save preset';
+      proxyBtn.className = 'Polaris-Button';
+      proxyBtn.style.cssText = 'margin-right: 8px;';
+      proxyBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new CustomEvent('alfred:save-preset'));
+      });
+      createStoreBtn.parentElement?.insertBefore(proxyBtn, createStoreBtn);
+    }
+
     // Explicitly mount the UI
     ui.mount();
 

--- a/entrypoints/collaborator-access.content/types.ts
+++ b/entrypoints/collaborator-access.content/types.ts
@@ -6,6 +6,7 @@ export interface Permission {
 export interface PermissionPreset {
   id: string;
   name: string;
+  handle: string;
   permissions: Permission[];
   customMessage?: string;
   createdAt: number;

--- a/entrypoints/collaborator-access.content/utils.ts
+++ b/entrypoints/collaborator-access.content/utils.ts
@@ -1,7 +1,10 @@
 import { getItem, setItem } from '@/utils/storage';
-import type { PermissionPreset, PresetStorageData } from './types';
+import type { PermissionPreset } from './types';
 
 const STORAGE_KEY = 'alfred:permission-presets';
+const HOTLINK_PRESET_PARAM = 'alfred_preset';
+
+type StoredPermissionPreset = PermissionPreset;
 
 /**
  * Generates a unique ID for a preset.
@@ -12,12 +15,99 @@ export function generatePresetId(): string {
 }
 
 /**
+ * Builds the hotlink URL for a preset using the current partner ID.
+ * @param handle - The preset handle to include in the hotlink
+ * @returns A collaborator request URL with the preset param appended
+ */
+export function buildHotlinkUrl(handle: string): string {
+  const url = new URL(window.location.href);
+  const partnerId = url.pathname.split('/').filter(Boolean)[0];
+
+  return `${url.host}/${partnerId}/stores/new?store_domain={{ customer.shopifyDomain }}&store_type=managed_store&${HOTLINK_PRESET_PARAM}=${handle}`;
+}
+
+/**
+ * Normalizes a preset handle into a URL-friendly slug.
+ * @param value - Raw handle input
+ * @returns The normalized handle, or null if empty after normalization
+ */
+export function normalizePresetHandle(value: string | undefined): string | null {
+  const normalized =
+    value
+      ?.trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') ?? '';
+  return normalized || null;
+}
+
+/**
+ * Ensures a preset handle is unique within the current preset collection.
+ * @param handle - Preferred handle, if one exists
+ * @param presets - Current set of presets to compare against
+ * @param currentPresetId - Current preset ID when updating an existing preset
+ * @returns A unique handle
+ */
+function ensureUniquePresetHandle(handle: string | undefined, presets: PermissionPreset[], currentPresetId?: string): string {
+  const existingHandles = new Set(presets.filter((preset) => preset.id !== currentPresetId).map((preset) => preset.handle));
+
+  const preferredHandle = normalizePresetHandle(handle);
+  if (preferredHandle && !existingHandles.has(preferredHandle)) {
+    return preferredHandle;
+  }
+
+  const baseHandle = preferredHandle ?? 'preset';
+  let suffix = 2;
+  let generatedHandle = `${baseHandle}-${suffix}`;
+
+  while (existingHandles.has(generatedHandle)) {
+    suffix += 1;
+    generatedHandle = `${baseHandle}-${suffix}`;
+  }
+
+  return generatedHandle;
+}
+
+/**
+ * Normalizes a stored preset before it is used in the app.
+ * @param preset - Stored preset record
+ * @param presets - Already-normalized presets used for uniqueness checks
+ * @returns A normalized preset ready for runtime use
+ */
+function normalizePreset(preset: StoredPermissionPreset, presets: PermissionPreset[]): PermissionPreset {
+  return {
+    ...preset,
+    name: preset.name.trim(),
+    handle: ensureUniquePresetHandle(preset.handle ?? preset.name, presets, preset.id),
+    createdAt: preset.createdAt || Date.now(),
+  };
+}
+
+/**
  * Retrieves all permissions presets from browser storage.
  * @returns Promise that resolves to an array of permissions presets, or empty array if none exist
  */
 export async function getPresets(): Promise<PermissionPreset[]> {
-  const data = await getItem<PresetStorageData>(STORAGE_KEY);
-  return data?.presets ?? [];
+  const data = await getItem<{ presets?: StoredPermissionPreset[] }>(STORAGE_KEY);
+  const storedPresets = data?.presets ?? [];
+  const normalizedPresets = storedPresets.reduce<PermissionPreset[]>((acc, preset) => {
+    acc.push(normalizePreset(preset, acc));
+    return acc;
+  }, []);
+
+  if (
+    storedPresets.length !== normalizedPresets.length ||
+    storedPresets.some(
+      (preset, index) =>
+        preset.handle !== normalizedPresets[index]?.handle ||
+        preset.name !== normalizedPresets[index]?.name ||
+        preset.createdAt !== normalizedPresets[index]?.createdAt,
+    )
+  ) {
+    await setItem(STORAGE_KEY, { presets: normalizedPresets });
+  }
+
+  return normalizedPresets;
 }
 
 /**
@@ -25,8 +115,14 @@ export async function getPresets(): Promise<PermissionPreset[]> {
  * @param presets - Array of permissions presets to save
  * @internal Used internally by savePreset and deletePreset functions
  */
-export async function savePresets(presets: PermissionPreset[]): Promise<void> {
-  await setItem(STORAGE_KEY, { presets });
+export async function savePresets(presets: StoredPermissionPreset[]): Promise<PermissionPreset[]> {
+  const normalizedPresets = presets.reduce<PermissionPreset[]>((acc, preset) => {
+    acc.push(normalizePreset(preset, acc));
+    return acc;
+  }, []);
+
+  await setItem(STORAGE_KEY, { presets: normalizedPresets });
+  return normalizedPresets;
 }
 
 /**
@@ -35,17 +131,19 @@ export async function savePresets(presets: PermissionPreset[]): Promise<void> {
  * If not, the preset will be added as a new entry.
  * @param preset - The permissions preset to save or update
  */
-export async function savePreset(preset: PermissionPreset): Promise<void> {
+export async function savePreset(preset: StoredPermissionPreset): Promise<PermissionPreset> {
   const presets = await getPresets();
+  const updatedPresets: StoredPermissionPreset[] = [...presets];
 
-  const existingIndex = presets.findIndex((p) => p.id === preset.id);
+  const existingIndex = updatedPresets.findIndex((p) => p.id === preset.id);
   if (existingIndex >= 0) {
-    presets[existingIndex] = preset;
+    updatedPresets[existingIndex] = preset;
   } else {
-    presets.push(preset);
+    updatedPresets.push(preset);
   }
 
-  await savePresets(presets);
+  const savedPresets = await savePresets(updatedPresets);
+  return savedPresets.find((savedPreset) => savedPreset.id === preset.id)!;
 }
 
 /**
@@ -94,7 +192,7 @@ export function importPresets(): Promise<number | null> {
 
       try {
         const text = await file.text();
-        const importedPresets = JSON.parse(text) as PermissionPreset[];
+        const importedPresets = JSON.parse(text) as StoredPermissionPreset[];
 
         if (!Array.isArray(importedPresets)) {
           throw new Error('Invalid file format. Expected an array of presets.');
@@ -103,10 +201,10 @@ export function importPresets(): Promise<number | null> {
         // Import each preset one by one
         let importCount = 0;
         for (const importedPreset of importedPresets) {
-          const newPreset: PermissionPreset = {
+          const newPreset: StoredPermissionPreset = {
             ...importedPreset,
             id: generatePresetId(),
-            createdAt: importedPreset.createdAt || Date.now()
+            createdAt: importedPreset.createdAt || Date.now(),
           };
 
           await savePreset(newPreset);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.02.26",
+  "version": "2026.03.15.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/utils/toast.ts
+++ b/utils/toast.ts
@@ -42,6 +42,10 @@ class AlfredToast extends HTMLElement {
   }
 }
 
+type ToastElement = HTMLElement & {
+  timeout?: ReturnType<typeof setTimeout> | null;
+};
+
 export class Toast {
   private static toastCounter = 0;
   private static customElementDefined = false;
@@ -146,11 +150,45 @@ export class Toast {
     }
   `;
 
+  private static getCustomElementRegistry(): CustomElementRegistry | null {
+    return globalThis.customElements ?? document.defaultView?.customElements ?? null;
+  }
+
   private static defineCustomElement() {
-    if (!this.customElementDefined && !customElements.get(this.defaults.hostTag)) {
-      customElements.define(this.defaults.hostTag, AlfredToast);
+    const registry = this.getCustomElementRegistry();
+    if (!registry) {
+      return;
+    }
+
+    if (!this.customElementDefined && !registry.get(this.defaults.hostTag)) {
+      registry.define(this.defaults.hostTag, AlfredToast);
       this.customElementDefined = true;
     }
+  }
+
+  private static setAutoHide(toastElement: ToastElement, duration: number) {
+    if (toastElement.timeout) {
+      clearTimeout(toastElement.timeout);
+    }
+
+    toastElement.timeout = setTimeout(() => {
+      this.hideToast(toastElement);
+    }, duration);
+  }
+
+  private static hideToast(toastElement: ToastElement) {
+    if (toastElement.timeout) {
+      clearTimeout(toastElement.timeout);
+      toastElement.timeout = null;
+    }
+
+    toastElement.classList.remove('alfred-toast--show');
+    toastElement.classList.add('alfred-toast--hide');
+
+    setTimeout(() => {
+      toastElement.hidePopover?.();
+      toastElement.remove();
+    }, 400);
   }
 
   static show(message: string, type: 'success' | 'error' = 'success', duration: number = this.defaults.duration) {
@@ -163,7 +201,7 @@ export class Toast {
     // If there are existing toasts, wait for them to hide before showing new one
     if (existingToasts.length > 0) {
       existingToasts.forEach((toast) => {
-        (toast as AlfredToast).hide();
+        this.hideToast(toast as ToastElement);
       });
 
       // Delay showing new toast until old one has mostly faded out
@@ -179,9 +217,11 @@ export class Toast {
 
   private static create(message: string, type: 'success' | 'error', duration: number) {
     // Create new toast element
-    const toastElement = document.createElement(this.defaults.hostTag) as AlfredToast;
+    const toastElement = document.createElement(this.defaults.hostTag) as ToastElement;
     const toastId = `alfred-toast-${++this.toastCounter}`;
     toastElement.id = toastId;
+    toastElement.setAttribute('popover', 'manual');
+    toastElement.classList.add('alfred-toast');
 
     // Check for PBarNextFrameWrapper and adjust bottom position
     const pBarWrapper = document.querySelector<HTMLElement>('#PBarNextFrameWrapper');
@@ -217,7 +257,7 @@ export class Toast {
 
     // Add event listener to close button
     const closeBtn = toast.querySelector('.alfred-toast__close')!;
-    closeBtn.addEventListener('click', () => toastElement.hide());
+    closeBtn.addEventListener('click', () => this.hideToast(toastElement));
 
     shadowRoot.appendChild(toast);
 
@@ -225,7 +265,7 @@ export class Toast {
     document.body.appendChild(toastElement);
 
     // Show popover
-    toastElement.showPopover();
+    toastElement.showPopover?.();
 
     // Add show class after next frame to trigger animation
     requestAnimationFrame(() => {
@@ -234,7 +274,7 @@ export class Toast {
 
     // Set auto-hide if duration is specified
     if (duration > 0) {
-      toastElement.setAutoHide(duration);
+      this.setAutoHide(toastElement, duration);
     }
   }
 

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   manifest: {
     name: 'Alfred - Shopify Theme Detector',
     description: 'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.02.26',
+    version: '2026.03.15.1',
     action: {
       default_title: 'Alfred',
     },
@@ -39,9 +39,10 @@ export default defineConfig({
       '--disable-features=BlockThirdPartyCookies', // Allows third-party cookies
       // 'chrome-extension://lepphhjodhfojboecomikglfppimdkmj/options.html',
       // 'https://uptek.com',
-      'https://junaid-workspace.myshopify.com/',
+      // 'https://junaid-workspace.myshopify.com/',
       // 'https://partners.shopify.com/1750954/stores/new?store_type=managed_store',
-      // 'https://admin.shopify.com/store/junaid-workspace/themes'
+      // 'https://admin.shopify.com/store/junaid-workspace/themes',
+      'https://partners.shopify.com/1750954/stores/new?store_domain=zeeshan-h-bhatti.myshopify.com&store_type=managed_store',
     ],
   },
 });


### PR DESCRIPTION
## Summary
- Renamed Mantle-specific feature to general-purpose "preset hotlinks" — shareable URLs that auto-apply a preset's permissions via the `alfred_preset` query param
- Hotlink modal explains usage as a bookmark, shared link, or platform integration, with a dedicated Mantle integration note
- Fixed bug where renaming a preset did not update the handle
- Replaced alerts with toast notifications across all preset actions
- Added handle column to presets table, replaced "Created" column
- Added auto-apply from URL parameter with handle and name matching
- Added `alfred:save-preset` custom event listener for external trigger support
- Version bump to 2026.03.15.1

## Pre-Landing Review
No issues found.

## Test plan
- [x] Build succeeds (`bun run build`)
- [x] Hotlink modal opens with correct handle and URL for each preset
- [x] Copy button copies URL to clipboard
- [x] Renaming a preset updates its handle
- [x] URL with `?alfred_preset=<handle>` auto-applies the matching preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)