### PR TITLE
feat: preserve ?view= param in Open in Customizer shortcut

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "2026.03.27",
+    "date": "2026-03-27",
+    "changes": [
+      {
+        "type": "paragraph",
+        "content": "Open in Customizer now preserves the ?view= parameter from the current URL, so alternate template views carry over into the theme editor."
+      }
+    ]
+  },
+  {
     "version": "2026.03.24",
     "date": "2026-03-24",
     "changes": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.03.27
+@ 2026-03-27
+Open in Customizer now preserves the ?view= parameter from the current URL, so alternate template views carry over into the theme editor.
+
+
 ## 2026.03.24
 @ 2026-03-24
 - Added a review CTA in the Theme Detector popup. If Alfred's been saving you time, leave a quick rating — it helps other Shopify developers find it.

--- a/entrypoints/alfred-main-world.ts
+++ b/entrypoints/alfred-main-world.ts
@@ -198,7 +198,11 @@ export default defineUnlistedScript(() => {
 
         const themeId = win.Shopify?.theme?.id;
         const shopName = win.Alfred.getShopName();
-        const previewPath = encodeURIComponent(window.location.pathname);
+        const currentUrl = new URL(window.location.href);
+        const viewParam = currentUrl.searchParams.get('view');
+        const previewPath = encodeURIComponent(
+          viewParam ? `${window.location.pathname}?view=${viewParam}` : window.location.pathname
+        );
         const customizerUrl = `https://admin.shopify.com/store/${shopName}/themes/${themeId}/editor?previewPath=${previewPath}`;
 
         (win.Alfred.Toast as { success: (msg: string) => void }).success('Opening customizer...');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.03.24",
+  "version": "2026.03.27",
   "private": true,
   "type": "module",
   "scripts": {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   manifest: {
     name: 'Alfred - Shopify Theme Detector',
     description: 'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.03.24',
+    version: '2026.03.27',
     action: {
       default_title: 'Alfred',
     },


### PR DESCRIPTION
## Summary
- Open in Customizer now includes the `?view=` query parameter from the current URL in the `previewPath`, so alternate template views (e.g. `?view=json`) carry over into the theme editor.

## Test Coverage
No test framework configured (`.gstack/no-test-bootstrap`). Change is 5 lines in a single function — manually verified via TypeScript type-check (clean).

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Plan Completion
No plan file detected.

## TODOS
No TODO items completed in this PR.

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Manual: visit a Shopify store with `?view=something`, right-click > Alfred > Open in Customizer — verify the customizer URL includes `?view=something` in the previewPath
- [ ] Manual: visit a Shopify store without `?view=`, right-click > Alfred > Open in Customizer — verify existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)