### PR TITLE
feat: overhaul theme customizer resizers

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "2026.04.05",
+    "date": "2026-04-05",
+    "changes": [
+      {
+        "type": "list",
+        "content": [
+          "Drag-to-resize sidebars and preview in the Theme Customizer, rebuilt for Shopify's latest editor.",
+          "Live dimensions badge in the top bar shows the preview size in real time as you resize."
+        ]
+      }
+    ]
+  },
+  {
     "version": "2026.03.27",
     "date": "2026-03-27",
     "changes": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.04.05
+@ 2026-04-05
+- Drag-to-resize sidebars and preview in the Theme Customizer, rebuilt for Shopify's latest editor.
+- Live dimensions badge in the top bar shows the preview size in real time as you resize.
+
 ## 2026.03.27
 @ 2026-03-27
 Open in Customizer now preserves the ?view= parameter from the current URL, so alternate template views carry over into the theme editor.

--- a/entrypoints/theme-customizer.content/resizers.util.ts
+++ b/entrypoints/theme-customizer.content/resizers.util.ts
@@ -19,256 +19,312 @@ interface Resizer {
 const MIN_SIDEBAR_WIDTH = 100;
 const MIN_MAIN_WIDTH = 200;
 const MIN_MAIN_HEIGHT = 100;
-const RESIZERS_ATTACHED_ATTR = 'data-alfred-resizers-attached';
+const RESIZER_ATTR_PREFIX = 'data-alfred-resizer-';
+const DIMENSIONS_BADGE_ATTR = 'data-alfred-dimensions-badge';
 
 const BASE_DOT_STYLE: Partial<CSSStyleDeclaration> = {
   width: '8px',
   height: '20px',
   cursor: 'col-resize',
   backgroundImage: 'radial-gradient(circle, rgba(0,0,0,0.3) 1px, transparent 1px)',
-  backgroundSize: '4px 4px'
+  backgroundSize: '4px 4px',
+};
+
+const SELECTORS = {
+  frame: '[class^="Online-Store-UI-PowerFrame__MainInterior_"]',
+  main: '[class*="Online-Store-UI-Preview__Interior_"]',
+  primarySidebar: '#PowerFrame-PortalArea-PrimaryPanel',
+  secondarySidebar: '#PowerFrame-PortalArea-SecondaryPanel',
+} as const;
+
+let activeResizer: Resizer | null = null;
+let startCoords = { x: 0, y: 0 };
+let initialDimensions: Dimensions | null = null;
+let animationFrameId: number | null = null;
+
+const queryElements = () => ({
+  frame: document.querySelector<HTMLElement>(SELECTORS.frame),
+  main: document.querySelector<HTMLElement>(SELECTORS.main),
+  primarySidebar: document.querySelector<HTMLElement>(SELECTORS.primarySidebar),
+  secondarySidebar: document.querySelector<HTMLElement>(SELECTORS.secondarySidebar),
+});
+
+const onMouseMove = (e: MouseEvent) => {
+  if (!activeResizer || !initialDimensions) return;
+  if (animationFrameId) cancelAnimationFrame(animationFrameId);
+  animationFrameId = requestAnimationFrame(() => {
+    if (!activeResizer || !initialDimensions) return;
+    activeResizer.resize(e.clientX - startCoords.x, e.clientY - startCoords.y, initialDimensions);
+  });
+};
+
+const onMouseUp = () => {
+  if (animationFrameId) cancelAnimationFrame(animationFrameId);
+  const { main, frame } = queryElements();
+  if (activeResizer?.isMainResizer && main) {
+    main.style.pointerEvents = '';
+  }
+  if (!activeResizer?.isMainResizer && frame) {
+    frame.style.transition = '';
+  }
+  activeResizer = null;
+  document.body.style.cursor = '';
+  document.body.style.userSelect = '';
+  document.removeEventListener('mousemove', onMouseMove);
+  document.removeEventListener('mouseup', onMouseUp);
+};
+
+const onMouseDown = (e: MouseEvent, resizer: Resizer) => {
+  e.preventDefault();
+  const { main, primarySidebar, secondarySidebar } = queryElements();
+  const { frame } = queryElements();
+  if (main && resizer.isMainResizer) main.style.pointerEvents = 'none';
+  if (!resizer.isMainResizer && frame) frame.style.transition = 'none';
+  activeResizer = resizer;
+  startCoords = { x: e.clientX, y: e.clientY };
+  initialDimensions = {
+    primary: primarySidebar?.offsetWidth ?? 0,
+    secondary: secondarySidebar?.offsetWidth ?? 0,
+    main: {
+      width: main?.offsetWidth ?? 0,
+      height: main?.offsetHeight ?? 0,
+    },
+  };
+
+  browser.runtime.sendMessage({
+    type: 'track_action',
+    action: 'resize_theme_customizer',
+    metadata: {
+      type: resizer.type || 'unknown',
+      page_type: 'theme_customizer',
+    },
+  });
+
+  document.body.style.cursor = window.getComputedStyle(e.target as Element).cursor;
+  document.body.style.userSelect = 'none';
+  document.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('mouseup', onMouseUp);
+};
+
+const createResizer = (
+  element: Element,
+  styles: Partial<CSSStyleDeclaration>,
+  resizeFn: (dx: number, dy: number, dims: Dimensions) => void,
+  isMain = false,
+  type?: 'primary' | 'secondary' | 'main-horizontal' | 'main-vertical',
+): Resizer => {
+  const resizerEl = document.createElement('div');
+  Object.assign(resizerEl.style, {
+    position: 'absolute',
+    zIndex: '50',
+    ...styles,
+  });
+  element.appendChild(resizerEl);
+  console.log(`[Alfred Resizers] Created resizer: ${type ?? 'primary'}`);
+
+  const resizer: Resizer = {
+    element: resizerEl,
+    resize: resizeFn,
+    isMainResizer: isMain,
+    type: type ?? 'primary',
+  };
+  resizerEl.addEventListener('mousedown', (e) => onMouseDown(e, resizer));
+  return resizer;
+};
+
+const createSidebarResizer = (frame: HTMLElement, sidebar: HTMLElement, isPrimary: boolean) => {
+  const resizeVar = isPrimary ? '--power-frame-resize-left' : '--power-frame-resize-right';
+  const gridColVar = isPrimary ? '--power-frame-grid-col-left' : '--power-frame-grid-col-right';
+
+  const resizeFn = (dx: number, _dy: number, dims: Dimensions) => {
+    const newWidth = isPrimary ? dims.primary + dx : dims.secondary - dx;
+    if (newWidth < MIN_SIDEBAR_WIDTH) return;
+
+    const panelArea = sidebar.querySelector<HTMLElement>('div[class*="Online-Store-UI-Frame-PanelArea_"]');
+    if (panelArea) {
+      const originalWidth = isPrimary ? dims.primary : dims.secondary;
+      panelArea.style.width = newWidth === originalWidth ? '' : '100%';
+    }
+
+    // Set both: resize var for panel width, grid-col var for grid column
+    frame.style.setProperty(resizeVar, `${newWidth}px`);
+    frame.style.setProperty(gridColVar, `${newWidth}px`);
+  };
+
+  const styles: Partial<CSSStyleDeclaration> = {
+    ...BASE_DOT_STYLE,
+    top: '0.5rem',
+  };
+
+  if (isPrimary) {
+    styles.right = '0.75rem';
+  } else {
+    styles.left = '5px';
+  }
+
+  createResizer(sidebar, styles, resizeFn, false, isPrimary ? 'primary' : 'secondary');
+};
+
+const createDimensionsBadge = (main: HTMLElement) => {
+  const topBarSlot = document.querySelector<HTMLElement>('[class^="Online-Store-UI-TopBar_"] > div:nth-child(3)');
+  if (!topBarSlot) return;
+
+  const badge = document.createElement('span');
+  badge.setAttribute(DIMENSIONS_BADGE_ATTR, 'true');
+  // Corner-only frame around the dimensions text
+  const c = 'rgba(138,138,138,0.6)';
+  const s = '4px';
+  const g = `linear-gradient(${c},${c})`;
+  const bg = [
+    `${g} 0 0/${s} 1px no-repeat`,
+    `${g} 0 0/1px ${s} no-repeat`,
+    `${g} 100% 0/${s} 1px no-repeat`,
+    `${g} 100% 0/1px ${s} no-repeat`,
+    `${g} 0 100%/${s} 1px no-repeat`,
+    `${g} 0 100%/1px ${s} no-repeat`,
+    `${g} 100% 100%/${s} 1px no-repeat`,
+    `${g} 100% 100%/1px ${s} no-repeat`,
+  ].join(',');
+  badge.innerHTML = `<span data-alfred-dim-value style="display:inline-block;background:${bg};padding:0 8px;line-height:1.6"></span>`;
+  topBarSlot.prepend(badge);
+
+  const valueEl = badge.querySelector('[data-alfred-dim-value]')!;
+  const update = () => {
+    const w = Math.round(main.offsetWidth);
+    const h = Math.round(main.offsetHeight);
+    valueEl.textContent = `${w} × ${h}`;
+  };
+
+  update();
+  const ro = new ResizeObserver(update);
+  ro.observe(main);
+};
+
+let settingsCache: Record<string, boolean> | null = null;
+
+const getResizerSettings = async () => {
+  if (!settingsCache) {
+    const settings = await getItem<AlfredSettings>('settings');
+    settingsCache = settings?.themeCustomizer?.resizers ?? {
+      primarySidebar: true,
+      secondarySidebar: true,
+      previewHorizontal: true,
+      previewVertical: true,
+    };
+  }
+  return settingsCache;
 };
 
 const Resizers = async () => {
-  const frame = document.querySelector<HTMLElement>('[class^="Online-Store-UI-Frame_"]');
-  const main = document.querySelector<HTMLElement>('[class*="Online-Store-UI-Preview__Interior_"]');
-  const primarySidebar = document.querySelector<HTMLElement>('aside[class^="Online-Store-UI-Frame-Sidebar_"]');
-  const secondarySidebar = document.querySelector<HTMLElement>('[class*="Online-Store-UI-Frame-Sidebar--secondary_"]');
+  const { frame, main, primarySidebar, secondarySidebar } = queryElements();
 
-  if (!frame || !main || !primarySidebar || !secondarySidebar) {
-    return false;
+  console.log('[Alfred Resizers] Element check:', {
+    frame: !!frame,
+    main: !!main,
+    primarySidebar: !!primarySidebar,
+    secondarySidebar: !!secondarySidebar,
+  });
+
+  if (!frame && !main) return false;
+
+  // Allow the 1fr main column to shrink past its content's min-width.
+  // Shopify's default `1fr` has implicit min-width:auto which causes overflow.
+  if (frame && !frame.hasAttribute(`${RESIZER_ATTR_PREFIX}grid-fixed`)) {
+    frame.setAttribute(`${RESIZER_ATTR_PREFIX}grid-fixed`, 'true');
+    frame.style.gridTemplateColumns = 'var(--power-frame-grid-col-left) minmax(0, 1fr) var(--power-frame-grid-col-right) 0';
   }
 
-  // Check if resizers already attached
-  if (frame.hasAttribute(RESIZERS_ATTACHED_ATTR)) {
-    return true;
-  }
-
-  // Get settings to determine which resizers to show
-  const settings = await getItem<AlfredSettings>('settings');
-  const resizerSettings = settings?.themeCustomizer?.resizers ?? {
-    primarySidebar: true,
-    secondarySidebar: true,
-    previewHorizontal: true,
-    previewVertical: true
-  };
-
-  // Mark as attached to prevent duplicates
-  frame.setAttribute(RESIZERS_ATTACHED_ATTR, 'true');
-
-  let activeResizer: Resizer | null = null;
-  let startCoords: { x: number; y: number } = { x: 0, y: 0 };
-  let initialDimensions: Dimensions | null = null;
-  let animationFrameId: number | null = null;
-
-  const onMouseMove = (e: MouseEvent) => {
-    if (!activeResizer || !initialDimensions) return;
-
-    if (animationFrameId) {
-      cancelAnimationFrame(animationFrameId);
-    }
-
-    animationFrameId = requestAnimationFrame(() => {
-      if (!activeResizer || !initialDimensions) return;
-      const dx = e.clientX - startCoords.x;
-      const dy = e.clientY - startCoords.y;
-      activeResizer.resize(dx, dy, initialDimensions);
-    });
-  };
-
-  const onMouseUp = () => {
-    if (animationFrameId) {
-      cancelAnimationFrame(animationFrameId);
-    }
-
-    if (main && activeResizer?.isMainResizer) {
-      main.style.pointerEvents = '';
-    }
-
-    activeResizer = null;
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
-  };
-
-  const onMouseDown = (e: MouseEvent, resizer: Resizer) => {
-    e.preventDefault();
-    if (main && resizer.isMainResizer) {
-      main.style.pointerEvents = 'none';
-    }
-    activeResizer = resizer;
-    startCoords = { x: e.clientX, y: e.clientY };
-    initialDimensions = {
-      primary: primarySidebar.offsetWidth,
-      secondary: secondarySidebar.offsetWidth,
-      main: {
-        width: main.offsetWidth,
-        height: main.offsetHeight
-      }
-    };
-
-    // Track resize event
-    browser.runtime.sendMessage({
-      type: 'track_action',
-      action: 'resize_theme_customizer',
-      metadata: {
-        type: resizer.type || 'unknown',
-        page_type: 'theme_customizer'
-      }
-    });
-
-    document.body.style.cursor = window.getComputedStyle(e.target as Element).cursor;
-    document.body.style.userSelect = 'none';
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  };
-
-  const createResizer = (
-    element: Element,
-    styles: Partial<CSSStyleDeclaration>,
-    resizeFn: (dx: number, dy: number, dims: Dimensions) => void,
-    isMain = false,
-    type?: 'primary' | 'secondary' | 'main-horizontal' | 'main-vertical'
-  ): Resizer => {
-    const resizerEl = document.createElement('div');
-    Object.assign(resizerEl.style, {
-      position: 'absolute',
-      zIndex: '50',
-      ...styles
-    });
-    element.appendChild(resizerEl);
-
-    const resizer: Resizer = {
-      element: resizerEl,
-      resize: resizeFn,
-      isMainResizer: isMain,
-      type: type ?? 'primary'
-    };
-    resizerEl.addEventListener('mousedown', (e) => onMouseDown(e, resizer));
-    return resizer;
-  };
-
-  const createSidebarResizer = (sidebar: HTMLElement, isPrimary: boolean) => {
-    const resizeFn = (dx: number, _dy: number, dims: Dimensions) => {
-      const newWidth = isPrimary ? dims.primary + dx : dims.secondary - dx;
-      if (newWidth < MIN_SIDEBAR_WIDTH) return;
-
-      const panelArea = sidebar.querySelector<HTMLElement>('div[class*="Online-Store-UI-Frame-PanelArea_"]');
-      if (panelArea) {
-        const originalWidth = isPrimary ? dims.primary : dims.secondary;
-        panelArea.style.width = newWidth === originalWidth ? '' : '100%';
-      }
-
-      if (isPrimary) {
-        frame.style.gridTemplateColumns = `minmax(0, auto) ${newWidth}px 1fr ${dims.secondary}px`;
-      } else {
-        frame.style.gridTemplateColumns = `minmax(0, auto) ${dims.primary}px 1fr ${newWidth}px`;
-      }
-    };
-
-    const styles: Partial<CSSStyleDeclaration> = {
-      ...BASE_DOT_STYLE,
-      top: isPrimary ? 'calc(var(--p-space-300) + var(--p-space-050))' : 'var(--p-space-300)'
-    };
-
-    if (isPrimary) {
-      styles.right = 'var(--p-space-400)';
-    } else {
-      styles.left = '2px';
-    }
-
-    createResizer(sidebar, styles, resizeFn, false, isPrimary ? 'primary' : 'secondary');
-  };
+  const resizerSettings = await getResizerSettings();
+  let newlyAttached = false;
 
   // Primary Sidebar Resizer
-  if (primarySidebar && resizerSettings.primarySidebar !== false) {
-    createSidebarResizer(primarySidebar, true);
+  if (frame && primarySidebar && resizerSettings.primarySidebar !== false && !primarySidebar.hasAttribute(`${RESIZER_ATTR_PREFIX}primary`)) {
+    primarySidebar.setAttribute(`${RESIZER_ATTR_PREFIX}primary`, 'true');
+    createSidebarResizer(frame, primarySidebar, true);
+    newlyAttached = true;
   }
 
   // Secondary Sidebar Resizer
-  if (secondarySidebar && resizerSettings.secondarySidebar !== false) {
-    createSidebarResizer(secondarySidebar, false);
+  if (frame && secondarySidebar && resizerSettings.secondarySidebar !== false && !secondarySidebar.hasAttribute(`${RESIZER_ATTR_PREFIX}secondary`)) {
+    secondarySidebar.setAttribute(`${RESIZER_ATTR_PREFIX}secondary`, 'true');
+    createSidebarResizer(frame, secondarySidebar, false);
+    newlyAttached = true;
   }
 
-  if (main) {
-    // Main Horizontal Resizer
-    if (resizerSettings.previewHorizontal !== false) {
-      createResizer(
-        main,
-        {
-          ...BASE_DOT_STYLE,
-          top: '50%',
-          right: '-8px',
-          transform: 'translateY(-50%)',
-          height: '40px'
-        },
-        (dx: number, _dy: number, dims: Dimensions) => {
-          const newWidth = dims.main.width + dx;
-          if (newWidth < MIN_MAIN_WIDTH) return;
-          main.style.maxWidth = `${newWidth}px`;
-        },
-        true,
-        'main-horizontal'
-      );
-    }
-
-    // Main Vertical Resizer
-    if (resizerSettings.previewVertical !== false) {
-      createResizer(
-        main,
-        {
-          ...BASE_DOT_STYLE,
-          top: '-8px',
-          left: '50%',
-          transform: 'translateX(-50%)',
-          width: '40px',
-          height: '8px',
-          cursor: 'row-resize'
-        },
-        (_dx: number, dy: number, dims: Dimensions) => {
-          const newHeight = dims.main.height - dy;
-          if (newHeight < MIN_MAIN_HEIGHT) return;
-          main.style.maxHeight = `${newHeight}px`;
-        },
-        true,
-        'main-vertical'
-      );
-    }
+  // Main Horizontal Resizer
+  if (main && resizerSettings.previewHorizontal !== false && !main.hasAttribute(`${RESIZER_ATTR_PREFIX}horizontal`)) {
+    main.setAttribute(`${RESIZER_ATTR_PREFIX}horizontal`, 'true');
+    createResizer(
+      main,
+      {
+        ...BASE_DOT_STYLE,
+        top: '50%',
+        right: '-8px',
+        transform: 'translateY(-50%)',
+        height: '40px',
+      },
+      (dx: number, _dy: number, dims: Dimensions) => {
+        const newWidth = dims.main.width + dx;
+        if (newWidth < MIN_MAIN_WIDTH) return;
+        main.style.maxWidth = `${newWidth}px`;
+      },
+      true,
+      'main-horizontal',
+    );
+    newlyAttached = true;
   }
 
-  return true;
+  // Main Vertical Resizer
+  if (main && resizerSettings.previewVertical !== false && !main.hasAttribute(`${RESIZER_ATTR_PREFIX}vertical`)) {
+    main.setAttribute(`${RESIZER_ATTR_PREFIX}vertical`, 'true');
+    createResizer(
+      main,
+      {
+        ...BASE_DOT_STYLE,
+        top: '-8px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        width: '40px',
+        height: '8px',
+        cursor: 'row-resize',
+      },
+      (_dx: number, dy: number, dims: Dimensions) => {
+        const newHeight = dims.main.height - dy;
+        if (newHeight < MIN_MAIN_HEIGHT) return;
+        main.style.maxHeight = `${newHeight}px`;
+      },
+      true,
+      'main-vertical',
+    );
+    newlyAttached = true;
+  }
+
+  // Dimensions badge in top bar
+  if (main && !document.querySelector(`[${DIMENSIONS_BADGE_ATTR}]`)) {
+    createDimensionsBadge(main);
+  }
+
+  if (newlyAttached) {
+    console.log('[Alfred Resizers] Attached new resizers');
+  }
 };
 
 export const setupResizers = async () => {
-  // Try to initialize immediately
-  const success = await Resizers();
-  if (success) {
-    return;
-  }
+  console.log('[Alfred Resizers] setupResizers called');
+  await Resizers();
 
-  // If elements not found, set up a mutation observer
+  // Keep watching permanently. Shopify's React app destroys and recreates
+  // sidebar panels when they hide/show, so we need to re-attach resizers.
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   const observer = new MutationObserver(() => {
-    void (async () => {
-      const success = await Resizers();
-      if (success) {
-        observer.disconnect();
-      }
-    })();
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      void Resizers();
+    }, 100);
   });
 
   observer.observe(document.body, {
     childList: true,
-    subtree: true
+    subtree: true,
   });
-
-  // Also try again after a delay
-  setTimeout(() => {
-    void (async () => {
-      const success = await Resizers();
-      if (success) {
-        observer.disconnect();
-      }
-    })();
-  }, 2000);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.03.27",
+  "version": "2026.04.05",
   "private": true,
   "type": "module",
   "scripts": {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   manifest: {
     name: 'Alfred - Shopify Theme Detector',
     description: 'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.03.27',
+    version: '2026.04.05',
     action: {
       default_title: 'Alfred',
     },


### PR DESCRIPTION
## Summary

Rewrites the resizer system for Shopify's updated PowerFrame grid layout:

- **CSS var integration**: Sidebars resize via `--power-frame-resize-left/right` and `--power-frame-grid-col-left/right` custom properties instead of overriding `gridTemplateColumns` directly
- **All elements optional**: Each resizer independently checks if its target element exists and attaches itself. No more all-or-nothing guard
- **Auto re-attach**: Permanent MutationObserver detects when Shopify destroys/recreates sidebar panels (e.g. clicking sections) and re-attaches resizers automatically
- **Grid overflow fix**: Overrides Shopify's `1fr` with `minmax(0, 1fr)` so the main column can shrink when sidebars grow
- **Dimensions badge**: Reactive `W × H` display in the top bar using ResizeObserver, with corner-frame styling
- **Transition handling**: Disables grid transition during sidebar drag to prevent 200ms lag

## Test plan
- [x] Primary sidebar resizer appears and resizes the grid
- [x] Secondary sidebar resizer appears when a section is selected
- [x] Resizers re-attach after navigating between sections
- [x] Main horizontal and vertical resizers work
- [x] Dimensions badge updates reactively during resize
- [x] No overflow when sidebars are expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)