### PR TITLE
feat: dev dashboard light mode

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "2026.04.05.1",
+    "date": "2026-04-05",
+    "changes": [
+      {
+        "type": "paragraph",
+        "content": "The Shopify Dev Dashboard now runs in light mode automatically, matching the Shopify Partners design language."
+      }
+    ]
+  },
+  {
     "version": "2026.04.05",
     "date": "2026-04-05",
     "changes": [

--- a/changelog.json
+++ b/changelog.json
@@ -5,7 +5,11 @@
     "changes": [
       {
         "type": "paragraph",
-        "content": "The Shopify Dev Dashboard now runs in light mode automatically, matching the Shopify Partners design language."
+        "content": "The Shopify Dev Dashboard now runs in light mode automatically, with a theme toggle in the header to switch between Light, Dark, and System. Your preference is remembered across sessions."
+      },
+      {
+        "type": "video",
+        "content": "https://bucket.alfred.uptek.com/alfred-dev-dashboard-light-mode.mp4"
       }
     ]
   },

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 2026.04.05.1
 @ 2026-04-05
-The Shopify Dev Dashboard now runs in light mode automatically, matching the Shopify Partners design language.
+The Shopify Dev Dashboard now runs in light mode automatically, with a theme toggle in the header to switch between Light, Dark, and System. Your preference is remembered across sessions.
 
 
 ## 2026.04.05

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.04.05.1
+@ 2026-04-05
+The Shopify Dev Dashboard now runs in light mode automatically, matching the Shopify Partners design language.
+
+
 ## 2026.04.05
 @ 2026-04-05
 - Drag-to-resize sidebars and preview in the Theme Customizer, rebuilt for Shopify's latest editor.

--- a/entrypoints/dev-dashboard.content.ts
+++ b/entrypoints/dev-dashboard.content.ts
@@ -1,0 +1,95 @@
+export default defineContentScript({
+  matches: ['https://dev.shopify.com/dashboard/*'],
+  runAt: 'document_start',
+
+  main() {
+    // Switch to built-in light theme
+    document.documentElement.classList.remove('dark');
+    document.documentElement.classList.add('light');
+    document.documentElement.style.colorScheme = 'light';
+
+    document.documentElement.style.setProperty(
+      '--color-background-surface-hover',
+      '#f5f5f5',
+    );
+
+    // Fix the few things the built-in .light theme doesn't handle
+    const style = document.createElement('style');
+    style.textContent = `
+      /* Sidebar container: right-side shadow */
+      html.light .w-desktop-nav-sidebar {
+        box-shadow: 1px 0px 1px #1f21241a !important;
+        overflow: visible !important;
+      }
+
+      /* Store switcher popover shadow */
+      html.light #store-switcher-popover {
+        overflow: visible !important;
+      }
+      html.light #store-switcher-popover > div {
+        box-shadow: 0px 3px 2px 0px #0000001a !important;
+      }
+
+      /* App icon SVGs: hardcoded dark teal bg */
+      html.light svg[aria-label="Default app icon"] {
+        background-color: #e3f1f3 !important;
+      }
+      html.light svg[aria-label="Default app icon"] path {
+        fill: #4b6468 !important;
+      }
+
+      /* Table light mode */
+      html.light .table,
+      html.light .table thead,
+      html.light .table tbody,
+      html.light .table tr,
+      html.light .table th,
+      html.light .table td {
+        background: transparent !important;
+        border: none !important;
+      }
+      html.light .table {
+        border-collapse: separate;
+        border-spacing: 0;
+        width: 100%;
+        border: 1px solid #f5f5f5 !important;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      html.light .table th {
+        color: #6d7175 !important;
+        font-weight: 600;
+        text-align: left;
+        padding: 10px 16px;
+        background-color: #f5f5f5 !important;
+      }
+      html.light .table td {
+        color: #202223 !important;
+        padding: 14px 16px;
+        border-top: 1px solid #f0f0f0 !important;
+      }
+      html.light .table tbody tr:hover {
+        background-color: #f5f5f5 !important;
+      }
+
+      /* Keep subdued/mono text gray */
+      html.light .text-text-subdued {
+        color: #6d7175 !important;
+      }
+      html.light .font-mono:not(a):not(a *) {
+        color: #8c9196 !important;
+      }
+    `;
+    // document.head may not exist yet at document_start
+    const inject = () => {
+      if (document.getElementById('alfred-dev-dashboard-light')) return;
+      style.id = 'alfred-dev-dashboard-light';
+      document.head.appendChild(style);
+    };
+    if (document.head) {
+      inject();
+    } else {
+      document.addEventListener('DOMContentLoaded', inject, { once: true });
+    }
+  },
+});

--- a/entrypoints/dev-dashboard.content.ts
+++ b/entrypoints/dev-dashboard.content.ts
@@ -1,95 +1,223 @@
+import { getItem, setItem } from '@/utils/storage';
+
+type ThemeMode = 'light' | 'dark' | 'system';
+const STORAGE_KEY = 'devDashboardTheme';
+
 export default defineContentScript({
   matches: ['https://dev.shopify.com/dashboard/*'],
   runAt: 'document_start',
 
-  main() {
-    // Switch to built-in light theme
-    document.documentElement.classList.remove('dark');
-    document.documentElement.classList.add('light');
-    document.documentElement.style.colorScheme = 'light';
+  async main() {
+    const saved = await getItem<ThemeMode>(STORAGE_KEY);
+    const mode = saved ?? 'light';
 
-    document.documentElement.style.setProperty(
-      '--color-background-surface-hover',
-      '#f5f5f5',
-    );
+    applyTheme(mode);
 
-    // Fix the few things the built-in .light theme doesn't handle
-    const style = document.createElement('style');
-    style.textContent = `
-      /* Sidebar container: right-side shadow */
-      html.light .w-desktop-nav-sidebar {
-        box-shadow: 1px 0px 1px #1f21241a !important;
-        overflow: visible !important;
-      }
-
-      /* Store switcher popover shadow */
-      html.light #store-switcher-popover {
-        overflow: visible !important;
-      }
-      html.light #store-switcher-popover > div {
-        box-shadow: 0px 3px 2px 0px #0000001a !important;
-      }
-
-      /* App icon SVGs: hardcoded dark teal bg */
-      html.light svg[aria-label="Default app icon"] {
-        background-color: #e3f1f3 !important;
-      }
-      html.light svg[aria-label="Default app icon"] path {
-        fill: #4b6468 !important;
-      }
-
-      /* Table light mode */
-      html.light .table,
-      html.light .table thead,
-      html.light .table tbody,
-      html.light .table tr,
-      html.light .table th,
-      html.light .table td {
-        background: transparent !important;
-        border: none !important;
-      }
-      html.light .table {
-        border-collapse: separate;
-        border-spacing: 0;
-        width: 100%;
-        border: 1px solid #f5f5f5 !important;
-        border-radius: 8px;
-        overflow: hidden;
-      }
-      html.light .table th {
-        color: #6d7175 !important;
-        font-weight: 600;
-        text-align: left;
-        padding: 10px 16px;
-        background-color: #f5f5f5 !important;
-      }
-      html.light .table td {
-        color: #202223 !important;
-        padding: 14px 16px;
-        border-top: 1px solid #f0f0f0 !important;
-      }
-      html.light .table tbody tr:hover {
-        background-color: #f5f5f5 !important;
-      }
-
-      /* Keep subdued/mono text gray */
-      html.light .text-text-subdued {
-        color: #6d7175 !important;
-      }
-      html.light .font-mono:not(a):not(a *) {
-        color: #8c9196 !important;
-      }
-    `;
-    // document.head may not exist yet at document_start
-    const inject = () => {
-      if (document.getElementById('alfred-dev-dashboard-light')) return;
-      style.id = 'alfred-dev-dashboard-light';
-      document.head.appendChild(style);
+    // Inject toggle and re-inject when SPA navigation rebuilds the header
+    const tryInject = async () => {
+      if (document.getElementById('alfred-theme-toggle')) return;
+      const current = (await getItem<ThemeMode>(STORAGE_KEY)) ?? 'light';
+      applyTheme(current);
+      injectToggle(current);
     };
-    if (document.head) {
-      inject();
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => tryInject(), { once: true });
     } else {
-      document.addEventListener('DOMContentLoaded', inject, { once: true });
+      tryInject();
     }
+
+    // SPA navigation rebuilds the header, destroying our toggle.
+    // Debounced observer avoids excessive checks on rapid DOM mutations.
+    let debounceTimer: ReturnType<typeof setTimeout>;
+    const observer = new MutationObserver(() => {
+      if (document.getElementById('alfred-theme-toggle')) return;
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(tryInject, 200);
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
   },
 });
+
+function applyTheme(mode: ThemeMode) {
+  const resolved = mode === 'system' ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : mode;
+
+  const html = document.documentElement;
+
+  if (resolved === 'light') {
+    html.classList.remove('dark');
+    html.classList.add('light');
+    html.style.colorScheme = 'light';
+    html.style.setProperty('--color-background-surface-hover', '#f5f5f5');
+    injectLightFixesCSS();
+  } else {
+    html.classList.remove('light');
+    html.classList.add('dark');
+    html.style.colorScheme = 'dark';
+    html.style.removeProperty('--color-background-surface-hover');
+    removeLightFixesCSS();
+  }
+}
+
+function injectLightFixesCSS() {
+  if (document.getElementById('alfred-dev-dashboard-light')) return;
+  const style = document.createElement('style');
+  style.id = 'alfred-dev-dashboard-light';
+  style.textContent = `
+    html.light .w-desktop-nav-sidebar {
+      box-shadow: 1px 0px 1px #1f21241a !important;
+      overflow: visible !important;
+    }
+    html.light #store-switcher-popover { overflow: visible !important; }
+    html.light #store-switcher-popover > div { box-shadow: 0px 3px 2px 0px #0000001a !important; }
+    html.light svg[aria-label="Default app icon"] { background-color: #e3f1f3 !important; }
+    html.light svg[aria-label="Default app icon"] path { fill: #4b6468 !important; }
+    html.light .table, html.light .table thead, html.light .table tbody,
+    html.light .table tr, html.light .table th, html.light .table td {
+      background: transparent !important; border: none !important;
+    }
+    html.light .table {
+      border-collapse: separate; border-spacing: 0; width: 100%;
+      border: 1px solid #f5f5f5 !important; border-radius: 8px; overflow: hidden;
+    }
+    html.light .table th {
+      color: #6d7175 !important; font-weight: 600; text-align: left;
+      padding: 10px 16px; background-color: #f5f5f5 !important;
+    }
+    html.light .table td {
+      color: #202223 !important; padding: 14px 16px;
+      border-top: 1px solid #f0f0f0 !important;
+    }
+    html.light .table tbody tr:hover { background-color: #f5f5f5 !important; }
+    html.light .text-text-subdued { color: #6d7175 !important; }
+    html.light .font-mono:not(a):not(a *) { color: #8c9196 !important; }
+  `;
+  const append = () => document.head.appendChild(style);
+  if (document.head) append();
+  else document.addEventListener('DOMContentLoaded', append, { once: true });
+}
+
+function removeLightFixesCSS() {
+  document.getElementById('alfred-dev-dashboard-light')?.remove();
+}
+
+function injectToggle(currentMode: ThemeMode) {
+  const headerLastDiv = document.querySelector('header > div:last-child');
+  if (!headerLastDiv) return;
+
+  const container = document.createElement('div');
+  container.id = 'alfred-theme-toggle';
+  container.style.cssText =
+    'display:flex;align-items:center;gap:1px;margin-right:8px;padding:2px;border-radius:8px;background:var(--color-topnav-surface-active);position:relative;';
+
+  // Sliding pill indicator
+  const pill = document.createElement('div');
+  pill.style.cssText = 'position:absolute;border-radius:6px;transition:left 0.25s cubic-bezier(0.4,0,0.2,1),width 0.25s cubic-bezier(0.4,0,0.2,1);pointer-events:none;top:2px;bottom:2px;z-index:0;';
+  container.appendChild(pill);
+
+  let active = currentMode;
+
+  function updatePill() {
+    const isLight = document.documentElement.classList.contains('light');
+    const activeWrap = container.querySelector<HTMLElement>(`[data-wrap="${active}"]`);
+    if (activeWrap) {
+      const containerRect = container.getBoundingClientRect();
+      const wrapRect = activeWrap.getBoundingClientRect();
+      pill.style.left = (wrapRect.left - containerRect.left) + 'px';
+      pill.style.width = wrapRect.width + 'px';
+      pill.style.background = 'var(--color-topnav-background)';
+      pill.style.boxShadow = isLight ? '0 1px 3px rgba(0,0,0,0.1)' : '0 1px 3px rgba(0,0,0,0.3)';
+    }
+  }
+
+  function updateActive() {
+    container.querySelectorAll<HTMLButtonElement>('button').forEach((b) => {
+      const isActive = b.dataset.mode === active;
+      b.style.cssText = `
+        position:relative;z-index:1;
+        border:none;cursor:pointer;padding:4px 10px;border-radius:6px;
+        font-size:12px;font-weight:500;font-family:inherit;line-height:1.4;
+        transition:opacity 0.15s ease;
+        background:transparent;
+        color:var(--color-topnav-text);
+        opacity:${isActive ? '1' : '0.5'};
+      `;
+    });
+    requestAnimationFrame(updatePill);
+  }
+
+  const ICONS: Record<ThemeMode, string> = {
+    light:
+      '<svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><circle cx="10" cy="10" r="3.5"/><path d="M10 2.5v2M10 15.5v2M17.5 10h-2M4.5 10h-2M15.3 4.7l-1.4 1.4M6.1 13.9l-1.4 1.4M15.3 15.3l-1.4-1.4M6.1 6.1L4.7 4.7"/></svg>',
+    dark: '<svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M16.5 13.1A7 7 0 016.9 3.5a7 7 0 109.6 9.6z"/></svg>',
+    system:
+      '<svg width="16" height="16" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="10" cy="10" r="7"/><path d="M10 3v14" fill="currentColor"/><path d="M10 3a7 7 0 010 14z" fill="currentColor"/></svg>',
+  };
+
+  const modes: ThemeMode[] = ['light', 'dark', 'system'];
+
+  modes.forEach((value) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.innerHTML = ICONS[value];
+    btn.dataset.mode = value;
+
+    // Wrap in a positioned container for tooltip
+    const wrap = document.createElement('div');
+    wrap.dataset.wrap = value;
+    wrap.style.cssText = 'position:relative;display:flex;';
+
+    const tooltip = document.createElement('span');
+    tooltip.textContent = value.charAt(0).toUpperCase() + value.slice(1);
+    tooltip.style.cssText = `
+      position:absolute;top:100%;margin-top:10px;left:50%;transform:translateX(-50%);
+      padding:4px 10px;border-radius:6px;font-size:11px;font-weight:500;
+      white-space:nowrap;pointer-events:none;opacity:0;transition:opacity 0.15s;
+      background:var(--color-background-surface-default);color:var(--color-text-default);
+      box-shadow:0 2px 8px rgba(0,0,0,0.15);z-index:50;
+    `;
+    // Arrow
+    const arrow = document.createElement('span');
+    arrow.style.cssText = `
+      position:absolute;top:-3px;left:50%;transform:translateX(-50%) rotate(45deg);
+      width:8px;height:8px;border-radius:2px;
+      background:var(--color-background-surface-default);
+      box-shadow:-1px -1px 2px rgba(0,0,0,0.06);
+      z-index:-1;
+    `;
+    tooltip.appendChild(arrow);
+    wrap.appendChild(btn);
+    wrap.appendChild(tooltip);
+    wrap.addEventListener('mouseenter', () => {
+      tooltip.style.opacity = '1';
+      if (btn.dataset.mode !== active) {
+        btn.style.background = 'var(--color-topnav-surface-hover)';
+      }
+    });
+    wrap.addEventListener('mouseleave', () => {
+      tooltip.style.opacity = '0';
+      if (btn.dataset.mode !== active) {
+        btn.style.background = 'transparent';
+      }
+    });
+
+    btn.addEventListener('click', async () => {
+      active = value;
+      setItem(STORAGE_KEY, value);
+      applyTheme(value);
+      requestAnimationFrame(updateActive);
+    });
+
+    container.appendChild(wrap);
+  });
+
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (active === 'system') {
+      applyTheme('system');
+      requestAnimationFrame(updateActive);
+    }
+  });
+
+  headerLastDiv.prepend(container);
+  updateActive();
+}

--- a/entrypoints/dev-dashboard.content.ts
+++ b/entrypoints/dev-dashboard.content.ts
@@ -36,6 +36,14 @@ export default defineContentScript({
       debounceTimer = setTimeout(tryInject, 200);
     });
     observer.observe(document.documentElement, { childList: true, subtree: true });
+
+    // Listen for system color scheme changes once (not per-injection)
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', async () => {
+      const current = (await getItem<ThemeMode>(STORAGE_KEY)) ?? 'light';
+      if (current === 'system') {
+        applyTheme('system');
+      }
+    });
   },
 });
 
@@ -209,13 +217,6 @@ function injectToggle(currentMode: ThemeMode) {
     });
 
     container.appendChild(wrap);
-  });
-
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-    if (active === 'system') {
-      applyTheme('system');
-      requestAnimationFrame(updateActive);
-    }
   });
 
   headerLastDiv.prepend(container);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.04.05",
+  "version": "2026.04.05.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   manifest: {
     name: 'Alfred - Shopify Theme Detector',
     description: 'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.04.05',
+    version: '2026.04.05.1',
     action: {
       default_title: 'Alfred',
     },


### PR DESCRIPTION
## Summary
Add a light mode theme toggle to the Shopify Dev Dashboard (`dev.shopify.com/dashboard`).

- **New content script** (`entrypoints/dev-dashboard.content.ts`) that injects a light/dark/system toggle into the dashboard header
- **SPA persistence** — MutationObserver detects when the SPA rebuilds the header and re-injects the toggle with current theme from storage
- **Light mode CSS fixes** — custom styles for sidebar, tables, text, and icons to look clean in light mode
- **System mode** — respects `prefers-color-scheme` media query, listener registered once in `main()` to avoid leak on re-injection

## Pre-Landing Review
1 issue found, auto-fixed:
- Media query listener was inside `injectToggle()`, causing listener accumulation on SPA navigation. Moved to `main()` so it registers once.

## Test plan
- [x] TypeScript compiles clean (pre-existing error in unrelated `resizers.util.ts` only)
- [ ] Manual: load dev.shopify.com/dashboard, verify toggle appears
- [ ] Manual: switch between light/dark/system, verify theme applies
- [ ] Manual: navigate between routes, verify toggle persists
- [ ] Manual: change theme, navigate, verify chosen theme persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)