### PR TITLE
fix: prevent duplicate toggle injection via async mutex

### DIFF
--- a/entrypoints/dev-dashboard.content.ts
+++ b/entrypoints/dev-dashboard.content.ts
@@ -14,11 +14,17 @@ export default defineContentScript({
     applyTheme(mode);
 
     // Inject toggle and re-inject when SPA navigation rebuilds the header
+    let injecting = false;
     const tryInject = async () => {
-      if (document.getElementById('alfred-theme-toggle')) return;
-      const current = (await getItem<ThemeMode>(STORAGE_KEY)) ?? 'light';
-      applyTheme(current);
-      injectToggle(current);
+      if (injecting || document.getElementById('alfred-theme-toggle')) return;
+      injecting = true;
+      try {
+        const current = (await getItem<ThemeMode>(STORAGE_KEY)) ?? 'light';
+        applyTheme(current);
+        injectToggle(current);
+      } finally {
+        injecting = false;
+      }
     };
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- Fixes a race condition in the dev dashboard theme toggle where the MutationObserver's debounced callback and the async `tryInject` could both pass the `getElementById` check before either appends the toggle, resulting in duplicate toggles in the header
- Adds a simple boolean mutex that's set synchronously before any `await` in `tryInject`

## Test plan
- [ ] Navigate between routes on dev.shopify.com/dashboard rapidly, verify only one toggle appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)