### PR TITLE
fix: exclude Shopify admin from restore-right-click feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,3 +40,23 @@ supabase functions deploy track --project-ref obrjirdnqoiailhbsnmu
 
 When `assets/data/themes.json` is updated with fresh scraped data, use the
 `/prune-themes-json` skill to strip unused fields.
+
+## Skill routing
+
+When the user's request matches an available skill, ALWAYS invoke it using the Skill
+tool as your FIRST action. Do NOT answer directly, do NOT use other tools first.
+The skill has specialized workflows that produce better results than ad-hoc answers.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke office-hours
+- Bugs, errors, "why is this broken", 500 errors → invoke investigate
+- Ship, deploy, push, create PR → invoke ship
+- QA, test the site, find bugs → invoke qa
+- Code review, check my diff → invoke review
+- Update docs after shipping → invoke document-release
+- Weekly retro → invoke retro
+- Design system, brand → invoke design-consultation
+- Visual audit, design polish → invoke design-review
+- Architecture review → invoke plan-eng-review
+- Save progress, checkpoint, resume → invoke checkpoint
+- Code quality, health check → invoke health

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,23 +40,3 @@ supabase functions deploy track --project-ref obrjirdnqoiailhbsnmu
 
 When `assets/data/themes.json` is updated with fresh scraped data, use the
 `/prune-themes-json` skill to strip unused fields.
-
-## Skill routing
-
-When the user's request matches an available skill, ALWAYS invoke it using the Skill
-tool as your FIRST action. Do NOT answer directly, do NOT use other tools first.
-The skill has specialized workflows that produce better results than ad-hoc answers.
-
-Key routing rules:
-- Product ideas, "is this worth building", brainstorming → invoke office-hours
-- Bugs, errors, "why is this broken", 500 errors → invoke investigate
-- Ship, deploy, push, create PR → invoke ship
-- QA, test the site, find bugs → invoke qa
-- Code review, check my diff → invoke review
-- Update docs after shipping → invoke document-release
-- Weekly retro → invoke retro
-- Design system, brand → invoke design-consultation
-- Visual audit, design polish → invoke design-review
-- Architecture review → invoke plan-eng-review
-- Save progress, checkpoint, resume → invoke checkpoint
-- Code quality, health check → invoke health

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "2026.04.18",
+    "date": "2026-04-18",
+    "changes": [
+      {
+        "type": "paragraph",
+        "content": "Fixed an issue where copy, cut, and paste stopped working in Shopify admin pages like the custom pixel code editor. The restore-right-click feature was incorrectly activating on admin pages."
+      }
+    ]
+  },
+  {
     "version": "2026.04.06",
     "date": "2026-04-06",
     "changes": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,16 @@
 # Changelog
 
+## 2026.04.18
+@ 2026-04-18
+Fixed an issue where copy, cut, and paste stopped working in Shopify admin pages like the custom pixel code editor. The restore-right-click feature was incorrectly activating on admin pages.
+
+
 ## 2026.04.06
 @ 2026-04-06
 The Shopify Dev Dashboard now runs in light mode automatically, with a theme toggle in the header to switch between Light, Dark, and System. Your preference is remembered across sessions.
 
+
+<video controls muted playsinline src="https://bucket.alfred.uptek.com/alfred-dev-dashboard-light-mode.mp4"></video>
 
 ## 2026.04.05
 @ 2026-04-05

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.04.06",
+  "version": "2026.04.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/utils/restore-right-click.ts
+++ b/utils/restore-right-click.ts
@@ -13,7 +13,13 @@ const blockedEvents = ['contextmenu', 'copy', 'cut', 'paste', 'selectstart', 'dr
  * Early Shopify detection using HTML elements (available before JS globals).
  * This is more reliable than checking window.Shopify which loads later.
  */
-const isShopifyEarly = (): boolean => {
+const isShopifyStorefront = (): boolean => {
+  const isAdminUrl =
+    window.location.hostname === 'admin.shopify.com' ||
+    window.location.pathname.startsWith('/admin/');
+
+  if (isAdminUrl) return false;
+
   return (
     !!document.querySelector('link[href*="cdn.shopify.com"]') ||
     !!document.querySelector('meta[name="shopify-checkout-api-token"]')
@@ -26,7 +32,7 @@ const isShopifyEarly = (): boolean => {
  */
 export const initRestoreRightClick = (): void => {
   // Only run on Shopify sites to avoid conflicts with apps like Google Docs
-  if (!isShopifyEarly()) {
+  if (!isShopifyStorefront()) {
     return;
   }
 

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   manifest: {
     name: 'Alfred - Shopify Theme Detector',
     description: 'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.04.06',
+    version: '2026.04.18',
     action: {
       default_title: 'Alfred',
     },


### PR DESCRIPTION
## Summary

- **Bug fix:** The restore-right-click feature was intercepting `copy`, `cut`, and `paste` events on `admin.shopify.com`, breaking clipboard operations in Shopify admin code editors (custom pixel editor, theme code editor, etc.)
- **Root cause:** `isShopifyEarly()` detected the admin as a Shopify storefront because admin pages load assets from `cdn.shopify.com`. This triggered `EventTarget.prototype.addEventListener` to silently drop all clipboard event handlers.
- **Fix:** Renamed to `isShopifyStorefront()` and added an admin URL exclusion (`admin.shopify.com` hostname + `/admin/` pathname prefix).

## Pre-Landing Review

No issues found. Adversarial review caught one edge case (`/admin` too broad, fixed to `/admin/`).

## Test plan
- [x] Lint passes (0 warnings, 0 errors)
- [x] Manual verification: copy/paste works in Shopify admin custom pixel editor with extension installed
- [x] Manual verification: restore-right-click still works on storefronts that block right-click

🤖 Generated with [Claude Code](https://claude.com/claude-code)