### PR TITLE
feat(popup): add myshopify domain to hero section

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -5,6 +5,10 @@
     "changes": [
       {
         "type": "paragraph",
+        "content": "The store's .myshopify.com domain is now displayed in the popup, so you can quickly identify and copy it."
+      },
+      {
+        "type": "paragraph",
         "content": "Improvements to analytics tracking so we can better understand how Alfred is being used and catch issues earlier."
       },
       {
@@ -400,7 +404,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Fix: Improved theme detection for stores with strict security protocols."]
+        "content": [
+          "Fix: Improved theme detection for stores with strict security protocols."
+        ]
       }
     ]
   },
@@ -428,7 +434,9 @@
       },
       {
         "type": "list",
-        "content": ["Fix: Background service worker becoming inactive interrupting shortcuts."]
+        "content": [
+          "Fix: Background service worker becoming inactive interrupting shortcuts."
+        ]
       }
     ]
   },
@@ -511,7 +519,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["[BTS] Options page migrated to Preact for improved performance and maintainability"]
+        "content": [
+          "[BTS] Options page migrated to Preact for improved performance and maintainability"
+        ]
       }
     ]
   },
@@ -521,7 +531,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Fix changelog page on extension update"]
+        "content": [
+          "Fix changelog page on extension update"
+        ]
       }
     ]
   },
@@ -567,7 +579,9 @@
       },
       {
         "type": "list",
-        "content": ["[BTS] Integrated a new build process to automatically generate and update the changelog."]
+        "content": [
+          "[BTS] Integrated a new build process to automatically generate and update the changelog."
+        ]
       }
     ]
   },
@@ -581,7 +595,11 @@
       },
       {
         "type": "list",
-        "content": ["Resizable primary sidebar", "Resizable secondary sidebar", "Resizable main preview area"]
+        "content": [
+          "Resizable primary sidebar",
+          "Resizable secondary sidebar",
+          "Resizable main preview area"
+        ]
       },
       {
         "type": "video",
@@ -595,7 +613,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Add indexer for Shopify app search results"]
+        "content": [
+          "Add indexer for Shopify app search results"
+        ]
       },
       {
         "type": "video",
@@ -606,7 +626,9 @@
       },
       {
         "type": "list",
-        "content": ["[BTS] Switch to CalVer for versioning from SemVer 1.2.5"]
+        "content": [
+          "[BTS] Switch to CalVer for versioning from SemVer 1.2.5"
+        ]
       }
     ]
   },
@@ -616,7 +638,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Open Section shortcut: Add support for main sections by appending page type to the name"]
+        "content": [
+          "Open Section shortcut: Add support for main sections by appending page type to the name"
+        ]
       }
     ]
   },
@@ -626,7 +650,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Use `.shopify-section` to identify section wrapper for Open Section shortcut"]
+        "content": [
+          "Use `.shopify-section` to identify section wrapper for Open Section shortcut"
+        ]
       }
     ]
   },
@@ -636,7 +662,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Add apply button to presets table actions column"]
+        "content": [
+          "Add apply button to presets table actions column"
+        ]
       }
     ]
   },
@@ -646,7 +674,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Add shortcut to open sections in code editor"]
+        "content": [
+          "Add shortcut to open sections in code editor"
+        ]
       },
       {
         "type": "video",
@@ -660,14 +690,19 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Add import/export for permissions presets", "Add bulk delete for permissions presets"]
+        "content": [
+          "Add import/export for permissions presets",
+          "Add bulk delete for permissions presets"
+        ]
       },
       {
         "type": "divider"
       },
       {
         "type": "list",
-        "content": ["[BTS] Fix analytics disabling in development"]
+        "content": [
+          "[BTS] Fix analytics disabling in development"
+        ]
       }
     ]
   },
@@ -677,7 +712,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Add custom message support in permission presets"]
+        "content": [
+          "Add custom message support in permission presets"
+        ]
       },
       {
         "type": "video",
@@ -688,7 +725,9 @@
       },
       {
         "type": "list",
-        "content": ["[BTS] Add analytics tracking system for user actions and time savings"]
+        "content": [
+          "[BTS] Add analytics tracking system for user actions and time savings"
+        ]
       }
     ]
   },
@@ -698,7 +737,10 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Rename extension to Alfred", "Add collaborator permission presets"]
+        "content": [
+          "Rename extension to Alfred",
+          "Add collaborator permission presets"
+        ]
       },
       {
         "type": "video",
@@ -712,7 +754,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["New Shortcut: Clear Cart"]
+        "content": [
+          "New Shortcut: Clear Cart"
+        ]
       }
     ]
   },
@@ -722,7 +766,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["New Shortcut: Copy Theme Preview URL"]
+        "content": [
+          "New Shortcut: Copy Theme Preview URL"
+        ]
       },
       {
         "type": "video",
@@ -733,7 +779,9 @@
       },
       {
         "type": "list",
-        "content": ["[BTS] Fix: Run main.content at document_start to avoid race condition"]
+        "content": [
+          "[BTS] Fix: Run main.content at document_start to avoid race condition"
+        ]
       }
     ]
   },
@@ -757,7 +805,9 @@
     "changes": [
       {
         "type": "list",
-        "content": ["Add context menu to copy product JSON"]
+        "content": [
+          "Add context menu to copy product JSON"
+        ]
       }
     ]
   },
@@ -794,7 +844,10 @@
     "changes": [
       {
         "type": "list",
-        "content": ["[BTS] Add @wxt-dev/auto-icons", "[BTS] Add Chrome extension icon"]
+        "content": [
+          "[BTS] Add @wxt-dev/auto-icons",
+          "[BTS] Add Chrome extension icon"
+        ]
       }
     ]
   }

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 2026.05.13
 @ 2026-05-13
+The store's .myshopify.com domain is now displayed in the popup, so you can quickly identify and copy it.
+
 Improvements to analytics tracking so we can better understand how Alfred is being used and catch issues earlier.
 
 - Added activation tracking to measure how many users open the popup after installing.

--- a/entrypoints/popup/Theme.svelte
+++ b/entrypoints/popup/Theme.svelte
@@ -126,6 +126,12 @@
         {#if (developer || price) && currentVersion}<span class="hero__byline-dot"></span>{/if}
         {#if currentVersion}<span>v{currentVersion}</span>{/if}
       </div>
+      {#if storeInfo.shopDomain}
+        <div class="hero__store-url">
+          <span class="hero__store-domain">{storeInfo.shopDomain}</span>
+          <CopyIcon text={storeInfo.shopDomain} class="copy-trigger" />
+        </div>
+      {/if}
     </div>
     <div class="hero__actions">
       {#if themeStoreUrl}
@@ -409,6 +415,8 @@
   .hero__byline-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--text-muted); opacity: 0.5; }
   .hero__developer-link { color: var(--text-secondary); text-decoration: underline; text-decoration-color: var(--text-muted); text-underline-offset: 2px; transition: text-decoration-color 0.12s; }
   .hero__developer-link:hover { text-decoration-color: var(--text-secondary); }
+  .hero__store-url { display: flex; align-items: center; gap: 4px; margin-top: 4px; }
+  .hero__store-domain { font-family: 'SF Mono', ui-monospace, monospace; font-size: 11.5px; color: var(--text-muted); }
   .hero__actions { display: flex; gap: 6px; flex-shrink: 0; padding-bottom: 4px; }
 
   /* Btn block */


### PR DESCRIPTION
## Summary
- Adds the `.myshopify.com` domain URL back to the popup's theme hero section, which was dropped during the sidebar redesign
- Displayed as plain text (not a link, since you're already on the store) with a copy icon

## Test plan
- [x] Open popup on a Shopify store and verify the `.myshopify.com` domain appears below the byline
- [x] Verify the copy icon copies the domain to clipboard
- [x] Verify it doesn't show on non-Shopify sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)