### PR TITLE
v2026.05.20 fix(collaborator-access): SPA navigation, scroll, and hotlink improvements

### DIFF
--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -59,6 +59,12 @@ mixing the content block types below in any order.
 
 #### Content block types
 
+**Heading** — section title to group related changes:
+
+```json
+{ "type": "heading", "content": "Permission Preset Improvements" }
+```
+
 **Paragraph** — a single descriptive sentence or short paragraph:
 
 ```json
@@ -85,9 +91,11 @@ mixing the content block types below in any order.
 
 #### Typical patterns
 
-- Single feature: one `paragraph`
-- Multiple small changes: one `list`
-- Feature with demo: `paragraph` + `video` or `paragraph` + `image`
+- Single feature: `heading` + `paragraph`
+- Multiple related changes: `heading` + `list`
+- Feature with demo: `heading` + `paragraph` + `video` or `image`
+- Multiple topics in one release: repeat `heading` + content for each topic
+- Use headings liberally — they make the changelog scannable
 - Mix as needed — the UI renders them in order
 
 ## Important

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "2026.05.20",
+    "date": "2026-05-20",
+    "changes": [
+      { "type": "heading", "content": "Permission Preset Improvements" },
+      {
+        "type": "list",
+        "content": [
+          "Permission presets now appear correctly when navigating to a collaboration request via the Dev Dashboard sidebar.",
+          "The hotlink modal now shows a direct auto-apply URL you can bookmark or share, in addition to the Mantle integration URL.",
+          "Applying a preset scrolls to the bottom of the page so the Save preset and Request access buttons are visible."
+        ]
+      }
+    ]
+  },
+  {
     "version": "2026.05.16",
     "date": "2026-05-16",
     "changes": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026.05.20
+@ 2026-05-20
+
+### Permission Preset Improvements
+- Permission presets now appear correctly when navigating to a collaboration request via the Dev Dashboard sidebar.
+- The hotlink modal now shows a direct auto-apply URL you can bookmark or share, in addition to the Mantle integration URL.
+- Applying a preset scrolls to the bottom of the page so the Save preset and Request access buttons are visible.
+
 ## 2026.05.16
 @ 2026-05-16
 You can now opt out of anonymous usage analytics from Settings. When disabled, no data is sent externally — Alfred works fully offline.

--- a/entrypoints/collaborator-access.content/DevApp.svelte
+++ b/entrypoints/collaborator-access.content/DevApp.svelte
@@ -107,8 +107,13 @@
     }
 
     window.setTimeout(() => {
-      window.scrollTo({ top: Math.max(document.body.scrollHeight, document.documentElement.scrollHeight), behavior: 'smooth' });
-    }, 100 + permissions.length * 50 + 100);
+      const bottomBar = document.getElementById('alfred-collab-bottom-bar');
+      if (bottomBar) {
+        bottomBar.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      } else {
+        window.scrollTo({ top: Math.max(document.body.scrollHeight, document.documentElement.scrollHeight), behavior: 'smooth' });
+      }
+    }, 100 + permissions.length * 50 + 400);
 
     const updatedPreset = await savePreset({ ...preset, lastUsed: Date.now() });
     presets = presets.map((p) => (p.id === updatedPreset.id ? updatedPreset : p));

--- a/entrypoints/collaborator-access.content/DevApp.svelte
+++ b/entrypoints/collaborator-access.content/DevApp.svelte
@@ -107,12 +107,7 @@
     }
 
     window.setTimeout(() => {
-      const bottomBar = document.getElementById('alfred-collab-bottom-bar');
-      if (bottomBar) {
-        bottomBar.scrollIntoView({ behavior: 'smooth', block: 'end' });
-      } else {
-        window.scrollTo({ top: Math.max(document.body.scrollHeight, document.documentElement.scrollHeight), behavior: 'smooth' });
-      }
+      window.scrollTo({ top: Math.max(document.body.scrollHeight, document.documentElement.scrollHeight), behavior: 'smooth' });
     }, 100 + permissions.length * 50 + 400);
 
     const updatedPreset = await savePreset({ ...preset, lastUsed: Date.now() });

--- a/entrypoints/collaborator-access.content/DevApp.svelte
+++ b/entrypoints/collaborator-access.content/DevApp.svelte
@@ -19,6 +19,7 @@
   let selectedPreset = $state.raw<PermissionPreset | null>(null);
   let checkedPresets = $state.raw<Set<string>>(new Set());
   let hotlinkUrl = $state('');
+  let hotlinkBareUrl = $state('');
   let hotlinkHandle = $state('');
   let autoApplyAttempted = $state(false);
   let showHotlinkModal = $state(false);
@@ -162,6 +163,9 @@
    */
   function handleOpenHotlinkModal(preset: PermissionPreset) {
     hotlinkUrl = buildHotlinkUrl(preset.handle, adapter.type);
+    const bare = new URL(window.location.href);
+    bare.searchParams.set('alfred_preset', preset.handle);
+    hotlinkBareUrl = bare.toString();
     hotlinkHandle = preset.handle;
     showHotlinkModal = true;
   }
@@ -252,6 +256,18 @@
     <p class="text-body-sm text-text-subdued mb-4">
       <em>Note: Renaming the preset changes the handle and breaks existing hotlinks.</em>
     </p>
+    <div class="flex gap-2 items-center mb-4">
+      <input
+        type="text"
+        class="w-full h-8 rounded bg-background-surface-default px-3 text-body-sm"
+        style="border:1px solid #59767A;flex:1;"
+        value={hotlinkBareUrl}
+        readonly
+      >
+      <button class="button button-variant-primary button-size-medium" style="height:32px;" onclick={() => navigator.clipboard.writeText(hotlinkBareUrl).then(() => Toast.success('URL copied')).catch(() => Toast.error('Failed to copy URL'))} aria-label="Copy URL">
+        <svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor"><path fill-rule="evenodd" d="M6.515 4.75a2 2 0 0 1 1.985-1.75h3a2 2 0 0 1 1.985 1.75h.265a2.25 2.25 0 0 1 2.25 2.25v7.75a2.25 2.25 0 0 1-2.25 2.25h-7.5a2.25 2.25 0 0 1-2.25-2.25v-7.75a2.25 2.25 0 0 1 2.25-2.25h.265Zm1.985-.25h3a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5Zm-1.987 1.73.002.02h-.265a.75.75 0 0 0-.75.75v7.75c0 .414.336.75.75.75h7.5a.75.75 0 0 0 .75-.75v-7.75a.75.75 0 0 0-.75-.75h-.265a2 2 0 0 1-1.985 1.75h-3a2 2 0 0 1-1.987-1.77Z"></path></svg>
+      </button>
+    </div>
     <div style="border-top:1px solid var(--color-border-default,#333);margin-bottom:16px;"></div>
     <p class="text-body-sm mb-3">
       <strong>Mantle</strong> — Use as a Mantle custom action by pasting the following URL into the custom action's URL field.
@@ -264,7 +280,7 @@
         value={hotlinkUrl}
         readonly
       >
-      <button class="button button-variant-primary button-size-medium" style="height:32px;" onclick={handleCopyHotlinkUrl} aria-label="Copy URL">
+      <button class="button button-variant-primary button-size-medium" style="height:32px;" onclick={handleCopyHotlinkUrl} aria-label="Copy Mantle URL">
         <svg viewBox="0 0 20 20" width="16" height="16" fill="currentColor"><path fill-rule="evenodd" d="M6.515 4.75a2 2 0 0 1 1.985-1.75h3a2 2 0 0 1 1.985 1.75h.265a2.25 2.25 0 0 1 2.25 2.25v7.75a2.25 2.25 0 0 1-2.25 2.25h-7.5a2.25 2.25 0 0 1-2.25-2.25v-7.75a2.25 2.25 0 0 1 2.25-2.25h.265Zm1.985-.25h3a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5Zm-1.987 1.73.002.02h-.265a.75.75 0 0 0-.75.75v7.75c0 .414.336.75.75.75h7.5a.75.75 0 0 0 .75-.75v-7.75a.75.75 0 0 0-.75-.75h-.265a2 2 0 0 1-1.985 1.75h-3a2 2 0 0 1-1.987-1.77Z"></path></svg>
       </button>
     </div>

--- a/entrypoints/collaborator-access.content/index.ts
+++ b/entrypoints/collaborator-access.content/index.ts
@@ -131,6 +131,7 @@ async function tryInjectDevDashboard(ctx: ContentScriptContext) {
   const formCard = messageCard?.closest('.card');
   if (formCard && submitBtn) {
     const bottomBar = document.createElement('div');
+    bottomBar.id = 'alfred-collab-bottom-bar';
     bottomBar.className = 'flex justify-end gap-2 mt-4 max-w-[768px]';
 
     const bottomSaveBtn = document.createElement('button');

--- a/entrypoints/collaborator-access.content/index.ts
+++ b/entrypoints/collaborator-access.content/index.ts
@@ -10,7 +10,7 @@ import type { ContentScriptContext } from '#imports';
 const ALFRED_SENTINEL_ID = 'alfred-collaborator-access';
 
 export default defineContentScript({
-  matches: ['*://partners.shopify.com/*/stores/new*', '*://dev.shopify.com/dashboard/*/stores/collaborations/*'],
+  matches: ['*://partners.shopify.com/*/stores/new*', '*://dev.shopify.com/dashboard/*'],
   async main(ctx) {
     const isPartnerDashboard = window.location.hostname === 'partners.shopify.com';
     const isDevDashboard = window.location.hostname === 'dev.shopify.com';

--- a/entrypoints/collaborator-access.content/index.ts
+++ b/entrypoints/collaborator-access.content/index.ts
@@ -131,7 +131,6 @@ async function tryInjectDevDashboard(ctx: ContentScriptContext) {
   const formCard = messageCard?.closest('.card');
   if (formCard && submitBtn) {
     const bottomBar = document.createElement('div');
-    bottomBar.id = 'alfred-collab-bottom-bar';
     bottomBar.className = 'flex justify-end gap-2 mt-4 max-w-[768px]';
 
     const bottomSaveBtn = document.createElement('button');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.05.16",
+  "version": "2026.05.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     name: 'Alfred - Shopify Theme Detector',
     description:
       'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.05.16',
+    version: '2026.05.20',
     action: {
       default_title: 'Alfred'
     },


### PR DESCRIPTION
## Summary

### Permission Preset SPA Navigation Fix
- Widened the dev dashboard content script match pattern from `/stores/collaborations/*` to `/dashboard/*` so permission presets load correctly during client-side SPA navigation (`index.ts:13`)

### Scroll After Preset Apply
- Increased scroll delay from 200ms to 500ms after applying a preset, giving section expand animations time to settle before scrolling to the page bottom (`DevApp.svelte:109`)

### Hotlink Modal: Bare Auto-Apply URL
- Added a direct auto-apply URL (current page + `?alfred_preset=<handle>`) to the hotlink modal, above the existing Mantle integration URL (`DevApp.svelte:256-267`)
- Each URL section has its own copy button

### Housekeeping
- Updated version-bump skill to recommend headings in changelog entries
- Bumped version to 2026.05.20

## Pre-Landing Review
No issues found.

## Test plan
- [x] Navigate to dev.shopify.com dashboard (non-collaborations page), then SPA-navigate to collaborations/new -- presets card should appear
- [x] Apply a preset and verify page scrolls to show Save preset + Request access buttons
- [x] Open hotlink modal and verify bare URL appears above the Mantle section with working copy button