### PR TITLE
v2026.06.01.1 feat(popup): calmer, more legible UI

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,29 @@
 [
   {
+    "version": "2026.06.01.1",
+    "date": "2026-06-01",
+    "changes": [
+      {
+        "type": "heading",
+        "content": "Popup redesign for legibility and calm"
+      },
+      {
+        "type": "paragraph",
+        "content": "The popup got a visual refresh focused on readability and a soothing feel, with no change to how anything works."
+      },
+      {
+        "type": "list",
+        "content": [
+          "A single calm indigo accent across links, filters, toggles, and active states.",
+          "Higher text contrast throughout for easier reading, meeting WCAG AA.",
+          "Softer off-white surfaces and gentler, cooler shadows that reduce glare.",
+          "Clearer, consistent heading-level pills (H1 through H6) in the Headings tab.",
+          "Crisper active tab and theme title, plus reduced-motion and keyboard-focus support."
+        ]
+      }
+    ]
+  },
+  {
     "version": "2026.06.01",
     "date": "2026-06-01",
     "changes": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026.06.01.1
+@ 2026-06-01
+
+### Popup redesign for legibility and calm
+The popup got a visual refresh focused on readability and a soothing feel, with no change to how anything works.
+
+- A single calm indigo accent across links, filters, toggles, and active states.
+- Higher text contrast throughout for easier reading, meeting WCAG AA.
+- Softer off-white surfaces and gentler, cooler shadows that reduce glare.
+- Clearer, consistent heading-level pills (H1 through H6) in the Headings tab.
+- Crisper active tab and theme title, plus reduced-motion and keyboard-focus support.
+
 ## 2026.06.01
 @ 2026-06-01
 
@@ -13,7 +25,7 @@ Introducing the new Assets tab — it shows every script and stylesheet a page l
 - Browser-extension assets injected into the page are detected and kept separate from the site's own assets.
 - Export everything as CSV or JSON, or copy the source URLs to your clipboard.
 
-<video controls autoplay loop muted playsinline src="https://bucket.alfred.uptek.com/alfred-assets.mp4"></video>
+<video controls muted playsinline src="https://bucket.alfred.uptek.com/alfred-assets.mp4"></video>
 
 ## 2026.05.31
 @ 2026-05-31

--- a/designs/popup-mockup.html
+++ b/designs/popup-mockup.html
@@ -2,9 +2,27 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Alfred Popup — B v2</title>
+    <title>Alfred Popup - B v2</title>
     <style>
-      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&display=swap');
+      :root {
+        /* calm indigo accent - replaces the AI-purple, desaturated for restfulness */
+        --accent: #4f57c4;
+        --accent-strong: #424ab4;
+        --accent-tint: #eef0fb;
+        /* neutrals */
+        --ink: #1d1d20;
+        --muted: #666c77;
+        --border: #ececef;
+        /* surfaces - soft off-white, never pure #fff, to ease glare */
+        --bg: #fbfbfc;
+        --sidebar: #f6f7f9;
+        /* radii */
+        --r-sm: 8px;
+        --r-md: 10px;
+        --r-pill: 999px;
+        /* accent focus ring (a11y) */
+        --ring: 0 0 0 3px rgba(79, 87, 196, 0.28);
+      }
 
       * {
         margin: 0;
@@ -13,11 +31,12 @@
       }
 
       body {
-        font-family:
-          'Inter',
-          system-ui,
-          -apple-system,
-          sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Inter', system-ui, sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+        color: var(--ink);
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
         background: #e8e8e8;
         display: flex;
         justify-content: center;
@@ -28,14 +47,14 @@
       .popup {
         width: 850px;
         height: 550px;
-        background: #fff;
+        background: var(--bg);
         border-radius: 14px;
         overflow: hidden;
         display: flex;
         flex-direction: column;
         box-shadow:
-          0 0 0 1px rgba(0, 0, 0, 0.03),
-          0 8px 40px rgba(0, 0, 0, 0.08);
+          0 0 0 1px rgba(29, 29, 46, 0.04),
+          0 10px 40px rgba(29, 29, 46, 0.1);
       }
 
       .layout {
@@ -47,7 +66,7 @@
       /* ── Sidebar ── */
       .sidebar {
         width: 192px;
-        background: #fafafa;
+        background: var(--sidebar);
         border-right: 1px solid #f0f0f0;
         display: flex;
         flex-direction: column;
@@ -72,7 +91,7 @@
       .brand span {
         font-size: 14px;
         font-weight: 700;
-        color: #111;
+        color: #1d1d20;
         letter-spacing: -0.01em;
       }
 
@@ -81,7 +100,7 @@
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.06em;
-        color: #8a8a8a;
+        color: #666c77;
         padding: 10px 14px 3px;
       }
 
@@ -94,7 +113,7 @@
         border-radius: 7px;
         font-size: 13.5px;
         font-weight: 500;
-        color: #777;
+        color: #666c77;
         cursor: pointer;
         border: none;
         background: none;
@@ -110,14 +129,11 @@
 
       .tab.active {
         background: #fff;
-        color: #111;
-        font-weight: 500;
-        text-shadow:
-          0 0 0.5px #111,
-          0 0 0.5px #111;
+        color: #1d1d20;
+        font-weight: 600;
         box-shadow:
-          0 1px 3px rgba(0, 0, 0, 0.05),
-          0 0 0 1px rgba(0, 0, 0, 0.03);
+          0 1px 2px rgba(29, 29, 46, 0.06),
+          0 0 0 1px rgba(29, 29, 46, 0.04);
       }
 
       .tab.disabled {
@@ -154,13 +170,13 @@
       }
 
       .badge-red {
-        background: #fee2e2;
-        color: #dc2626;
+        background: #fdeceb;
+        color: #c5342e;
       }
 
       .badge-green {
-        background: #dcfce7;
-        color: #16a34a;
+        background: #e8f6ee;
+        color: #15783f;
       }
 
       .divider {
@@ -179,7 +195,7 @@
       .content {
         flex: 1;
         overflow-y: auto;
-        background: #fff;
+        background: var(--bg);
       }
 
       .content::-webkit-scrollbar {
@@ -245,20 +261,20 @@
       .theme-header h2 {
         font-size: 22px;
         font-weight: 700;
-        color: #111;
+        color: #1d1d20;
         letter-spacing: -0.03em;
       }
 
       .theme-header .domain {
         font-size: 12.5px;
         font-family: 'SF Mono', ui-monospace, monospace;
-        color: #7c3aed;
+        color: #4f57c4;
         margin-top: 6px;
       }
 
       .theme-header .meta {
         font-size: 12.5px;
-        color: #aaaaaa;
+        color: #666c77;
         margin-top: 4px;
       }
 
@@ -278,7 +294,7 @@
       .row-label {
         font-size: 13.5px;
         font-weight: 500;
-        color: #999;
+        color: #666c77;
         flex-shrink: 0;
       }
 
@@ -295,7 +311,7 @@
       }
 
       .row-value a {
-        color: #7c3aed;
+        color: #4f57c4;
         text-decoration: none;
         font-size: 12.5px;
         font-family: ui-monospace, monospace;
@@ -309,7 +325,7 @@
         background: none;
         border: none;
         cursor: pointer;
-        color: #929292;
+        color: #666c77;
         font-size: 13px;
         padding: 2px;
         border-radius: 3px;
@@ -317,7 +333,7 @@
       }
 
       .copy-btn:hover {
-        color: #888;
+        color: #666c77;
       }
 
       .section-heading {
@@ -325,7 +341,7 @@
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.05em;
-        color: #bbbbbb;
+        color: #666c77;
         padding: 22px 0 10px;
       }
 
@@ -345,37 +361,37 @@
       }
 
       .pill-red {
-        background: #fef2f2;
-        color: #ef4444;
+        background: #fdeceb;
+        color: #c5342e;
       }
 
       .pill-green {
-        background: #f0fdf4;
-        color: #22c55e;
+        background: #e8f6ee;
+        color: #15783f;
       }
 
       .pill-yellow {
-        background: #fffbeb;
-        color: #eab308;
+        background: #faf1dd;
+        color: #9c4a08;
       }
 
       .pill-gray {
-        background: #f5f5f5;
-        color: #888;
+        background: #eceef2;
+        color: #565d6b;
       }
 
       .pill-purple {
-        background: #faf5ff;
-        color: #9333ea;
+        background: #eef0fb;
+        color: #4f57c4;
       }
 
       .missing {
-        color: #ef4444;
+        color: #c5342e;
         font-weight: 500;
       }
 
       .muted {
-        color: #929292;
+        color: #666c77;
       }
 
       /* input */
@@ -401,7 +417,13 @@
       }
 
       .input-field:focus {
-        border-color: #ddd;
+        border-color: #4f57c4;
+        box-shadow: var(--ring);
+      }
+
+      .input-field::placeholder,
+      .preview-url-input-v2::placeholder {
+        color: #666c77;
       }
 
       .btn {
@@ -409,7 +431,7 @@
         font-size: 13px;
         font-weight: 600;
         color: #fff;
-        background: #111;
+        background: #1d1d20;
         border: none;
         border-radius: 8px;
         cursor: pointer;
@@ -419,18 +441,22 @@
         background: #333;
       }
 
+      .btn:active {
+        transform: translateY(1px);
+      }
+
       .checkbox-row {
         display: flex;
         align-items: center;
         gap: 6px;
         margin-top: 8px;
         font-size: 12px;
-        color: #8a8a8a;
+        color: #666c77;
         cursor: pointer;
       }
 
       .checkbox-row input {
-        accent-color: #111;
+        accent-color: #1d1d20;
         width: 13px;
         height: 13px;
       }
@@ -448,7 +474,7 @@
       .stars-row p {
         font-size: 13px;
         font-weight: 500;
-        color: #999;
+        color: #666c77;
       }
 
       .stars {
@@ -479,8 +505,22 @@
       }
 
       .star-btn:focus-visible {
-        outline: 2px solid #7c3aed;
+        outline: 2px solid #4f57c4;
         outline-offset: 2px;
+      }
+
+      .tab:focus-visible,
+      .btn:focus-visible,
+      .action-btn:focus-visible,
+      .fpill:focus-visible,
+      .btn-v2-ghost:focus-visible,
+      .btn-v2-primary:focus-visible,
+      .quick-link-v2:focus-visible,
+      .copy-trigger-v2:focus-visible,
+      .copy-btn:focus-visible,
+      .content a:focus-visible {
+        outline: none;
+        box-shadow: var(--ring);
       }
 
       /* headings */
@@ -494,8 +534,8 @@
       .h-level {
         font-size: 11px;
         font-weight: 700;
-        color: #7c3aed;
-        background: #f5f3ff;
+        color: #4f57c4;
+        background: #eef0fb;
         padding: 2px 8px;
         border-radius: 6px;
         min-width: 30px;
@@ -535,7 +575,7 @@
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.04em;
-        color: #8a8a8a;
+        color: #666c77;
         padding: 7px 0;
         border-bottom: 1px solid #f0f0f0;
       }
@@ -547,7 +587,7 @@
       }
 
       td a {
-        color: #7c3aed;
+        color: #4f57c4;
         text-decoration: none;
         font-family: ui-monospace, monospace;
         font-size: 12px;
@@ -567,14 +607,14 @@
         border-radius: 20px;
         border: 1px solid #ebebeb;
         background: #fff;
-        color: #888;
+        color: #666c77;
         cursor: pointer;
       }
 
       .fpill.active {
-        background: #111;
+        background: #1d1d20;
         color: #fff;
-        border-color: #111;
+        border-color: #1d1d20;
       }
 
       /* images */
@@ -603,7 +643,7 @@
 
       .img-alt-label {
         font-size: 11.5px;
-        color: #8a8a8a;
+        color: #666c77;
       }
 
       .img-alt {
@@ -631,7 +671,7 @@
       .sch-header svg {
         width: 12px;
         height: 12px;
-        color: #929292;
+        color: #666c77;
         transition: transform 0.15s;
       }
 
@@ -656,7 +696,7 @@
       }
 
       .sch-k {
-        color: #8a8a8a;
+        color: #666c77;
         min-width: 74px;
       }
 
@@ -665,7 +705,7 @@
       }
 
       .sch-v a {
-        color: #7c3aed;
+        color: #4f57c4;
         text-decoration: none;
       }
 
@@ -717,14 +757,14 @@
 
       .stat-label {
         font-size: 12px;
-        color: #8a8a8a;
+        color: #666c77;
         font-weight: 500;
       }
 
       .stat-val {
         font-size: 22px;
         font-weight: 700;
-        color: #111;
+        color: #1d1d20;
         letter-spacing: -0.02em;
         margin-top: 2px;
       }
@@ -737,17 +777,17 @@
         align-items: center;
         justify-content: space-between;
         font-size: 11.5px;
-        color: #929292;
+        color: #666c77;
         flex-shrink: 0;
       }
 
       .footer strong {
-        color: #888;
+        color: #666c77;
         font-weight: 600;
       }
 
       .footer a {
-        color: #7c3aed;
+        color: #4f57c4;
         text-decoration: none;
         font-weight: 500;
       }
@@ -788,7 +828,7 @@
         padding: 5px 10px;
         font-size: 12px;
         font-weight: 500;
-        color: #777;
+        color: #666c77;
         background: #fff;
         border: 1px solid #ebebeb;
         border-radius: 6px;
@@ -846,7 +886,7 @@
 
       .app-desc {
         font-size: 11.5px;
-        color: #999;
+        color: #666c77;
         margin-top: 1px;
       }
 
@@ -854,7 +894,7 @@
       .empty-state {
         text-align: center;
         padding: 32px 20px;
-        color: #bababa;
+        color: #666c77;
         font-size: 13px;
       }
 
@@ -868,7 +908,7 @@
       .empty-state p {
         margin-top: 4px;
         font-size: 12px;
-        color: #ccc;
+        color: #666c77;
       }
 
       /* sidebar scroll */
@@ -898,8 +938,8 @@
         left: 0;
         right: 0;
         height: 140px;
-        background: linear-gradient(135deg, #fafafa 0%, #f5f5f5 50%, #f0f0f0 100%);
-        border-bottom: 1px solid #f0f0f0;
+        background: linear-gradient(135deg, #f4f5f8 0%, #eef0f4 55%, #f6f7f9 100%);
+        border-bottom: 1px solid #ececef;
       }
 
       .theme-identity-v2 {
@@ -917,12 +957,12 @@
       }
 
       .theme-name-v2 {
-        font-family: 'Instrument Serif', serif;
-        font-size: 28px;
-        font-weight: 400;
-        color: #111;
+        font-family: inherit;
+        font-size: 24px;
+        font-weight: 600;
+        color: #1d1d20;
         letter-spacing: -0.02em;
-        line-height: 1.1;
+        line-height: 1.15;
       }
 
       .theme-byline-v2 {
@@ -931,14 +971,14 @@
         gap: 6px;
         margin-top: 5px;
         font-size: 12.5px;
-        color: #929292;
+        color: #666c77;
       }
 
       .theme-byline-dot {
         width: 3px;
         height: 3px;
         border-radius: 50%;
-        background: #929292;
+        background: #666c77;
         opacity: 0.5;
       }
 
@@ -967,7 +1007,7 @@
 
       .btn-v2-ghost:hover {
         border-color: #ddd;
-        color: #111;
+        color: #1d1d20;
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
       }
 
@@ -985,7 +1025,7 @@
         font-size: 12px;
         font-weight: 600;
         color: #fff;
-        background: #111;
+        background: #1d1d20;
         border: none;
         border-radius: 6px;
         cursor: pointer;
@@ -1024,14 +1064,14 @@
       .stat-label-v2 {
         font-size: 11px;
         font-weight: 500;
-        color: #929292;
+        color: #666c77;
         letter-spacing: 0.02em;
       }
 
       .stat-value-v2 {
         font-size: 17px;
         font-weight: 600;
-        color: #111;
+        color: #1d1d20;
         margin-top: 3px;
         letter-spacing: -0.02em;
         display: flex;
@@ -1056,7 +1096,7 @@
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.06em;
-        color: #929292;
+        color: #666c77;
         margin-bottom: 12px;
         display: flex;
         align-items: center;
@@ -1116,7 +1156,7 @@
       }
 
       .toggle-track-v2.on {
-        background: #7c3aed;
+        background: #4f57c4;
       }
 
       .toggle-knob-v2 {
@@ -1159,7 +1199,7 @@
 
       .quick-link-v2:hover {
         border-color: #ddd;
-        color: #111;
+        color: #1d1d20;
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
       }
 
@@ -1179,7 +1219,7 @@
         background: none;
         border: none;
         cursor: pointer;
-        color: #929292;
+        color: #666c77;
         transition: all 0.12s;
       }
 
@@ -1196,7 +1236,7 @@
       @keyframes fadeUpV2 {
         from {
           opacity: 0;
-          transform: translateY(8px);
+          transform: translateY(6px);
         }
         to {
           opacity: 1;
@@ -1213,6 +1253,17 @@
       .theme-sections-v2 {
         animation: fadeUpV2 0.4s ease 0.15s both;
       }
+
+      /* Respect reduced-motion: collapse all entrance/transition motion to instant */
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.001ms !important;
+          animation-delay: 0ms !important;
+          transition-duration: 0.001ms !important;
+        }
+      }
     </style>
   </head>
 
@@ -1223,7 +1274,7 @@
           <svg
             viewBox="0 0 24 24"
             fill="none"
-            stroke="#111"
+            stroke="#1d1d20"
             stroke-width="2.2"
             stroke-linecap="round"
             stroke-linejoin="round"
@@ -1233,10 +1284,10 @@
             <path d="M2 17l10 5 10-5" />
             <path d="M2 12l10 5 10-5" />
           </svg>
-          <span style="font-size: 14px; font-weight: 700; color: #111; letter-spacing: -0.01em">Alfred</span>
+          <span style="font-size: 14px; font-weight: 700; color: #1d1d20; letter-spacing: -0.01em">Alfred</span>
         </div>
         <div style="display: flex; align-items: center; gap: 8px">
-          <span style="font-size: 12px; color: #999">Enjoying Alfred?</span>
+          <span style="font-size: 12px; color: #666c77">Enjoying Alfred?</span>
           <div class="stars" role="group" aria-label="Rate Alfred" onmouseleave="cs()" style="display: flex; gap: 1px">
             <button
               aria-label="Rate 1 star"
@@ -1506,7 +1557,7 @@
                 border-radius: 7px;
                 font-size: 12px;
                 font-weight: 500;
-                color: #999;
+                color: #666c77;
                 text-decoration: none;
                 transition: all 0.12s;
               ">
@@ -1540,12 +1591,12 @@
                         style="
                           color: #555;
                           text-decoration: underline;
-                          text-decoration-color: #929292;
+                          text-decoration-color: #666c77;
                           text-underline-offset: 2px;
                           transition: text-decoration-color 0.12s;
                         "
                         onmouseover="this.style.textDecorationColor = '#555'"
-                        onmouseout="this.style.textDecorationColor = '#929292'"
+                        onmouseout="this.style.textDecorationColor = '#666c77'"
                         >Shopify</a
                       ></span
                     >
@@ -1625,8 +1676,8 @@
                       font-weight: 600;
                       padding: 2px 7px;
                       border-radius: 20px;
-                      background: #fffbeb;
-                      color: #ca8a04;
+                      background: #faf1dd;
+                      color: #9c4a08;
                     ">
                     <svg
                       viewBox="0 0 12 12"
@@ -1646,7 +1697,7 @@
               <div class="stat-cell-v2">
                 <div class="stat-label-v2">Status</div>
                 <div class="stat-value-v2">
-                  <span style="width: 7px; height: 7px; border-radius: 50%; background: #22c55e"></span>
+                  <span style="width: 7px; height: 7px; border-radius: 50%; background: #15783f"></span>
                   Published
                 </div>
               </div>
@@ -1675,7 +1726,7 @@
                       font-weight: 600;
                       text-transform: uppercase;
                       letter-spacing: 0.06em;
-                      color: #929292;
+                      color: #666c77;
                       white-space: nowrap;
                     "
                     >Internal Name</span
@@ -1685,7 +1736,7 @@
                       font-family: 'SF Mono', ui-monospace, monospace;
                       font-size: 13px;
                       font-weight: 500;
-                      color: #111;
+                      color: #1d1d20;
                       letter-spacing: -0.01em;
                     "
                     >Dawn-15-0-0</span
@@ -1724,7 +1775,7 @@
                     <svg
                       viewBox="0 0 24 24"
                       fill="none"
-                      stroke="#929292"
+                      stroke="#666c77"
                       stroke-width="1.7"
                       stroke-linecap="round"
                       style="width: 14px; height: 14px; flex-shrink: 0">
@@ -1752,7 +1803,7 @@
                     <div class="toggle-track-v2" onclick="this.classList.toggle('on')">
                       <div class="toggle-knob-v2"></div>
                     </div>
-                    <span style="font-size: 11.5px; color: #929292; font-weight: 450">Hide preview bar</span>
+                    <span style="font-size: 11.5px; color: #666c77; font-weight: 450">Hide preview bar</span>
                   </div>
                 </div>
               </div>
@@ -1761,53 +1812,53 @@
               <div class="detail-section-v2">
                 <div class="section-title-v2">Reviews</div>
                 <div style="display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px">
-                  <span style="font-size: 26px; font-weight: 700; color: #111; letter-spacing: -0.03em"
+                  <span style="font-size: 26px; font-weight: 700; color: #1d1d20; letter-spacing: -0.03em"
                     >35% positive</span
                   >
                 </div>
                 <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 16px">
-                  <span style="font-size: 13px; color: #929292; font-weight: 450">272 reviews</span>
-                  <a href="#" style="font-size: 12px; color: #7c3aed; text-decoration: none; font-weight: 500"
+                  <span style="font-size: 13px; color: #666c77; font-weight: 450">272 reviews</span>
+                  <a href="#" style="font-size: 12px; color: #4f57c4; text-decoration: none; font-weight: 500"
                     >View all &rarr;</a
                   >
                 </div>
                 <div style="display: flex; flex-direction: column; gap: 10px">
                   <div style="display: flex; align-items: center; gap: 10px">
-                    <svg viewBox="0 0 20 20" width="18" height="18" style="flex-shrink: 0; color: #16a34a">
+                    <svg viewBox="0 0 20 20" width="18" height="18" style="flex-shrink: 0; color: #15783f">
                       <path
                         fill-rule="evenodd"
                         fill="currentColor"
                         d="M12.539 14.57a9.25 9.25 0 0 1-4.074-.838l-.307-.141a3.751 3.751 0 0 0-1.158-.32v-5.222a1.5 1.5 0 0 0 .15-.099 6.489 6.489 0 0 0 2.475-3.95 1.41 1.41 0 0 1 1.378 1.557l-.133 1.26a1.75 1.75 0 0 0 1.74 1.933h1.595c.758 0 1.342.67 1.239 1.42l-.338 2.449a2.25 2.25 0 0 1-2.176 1.942l-.391.01Zm-7.039-6.32h-1v5h1v-5Zm2.34 6.845a10.75 10.75 0 0 0 4.735.975l.391-.01a3.75 3.75 0 0 0 3.626-3.236l.337-2.448a2.75 2.75 0 0 0-2.724-3.126h-1.594a.25.25 0 0 1-.249-.276l.133-1.26a2.91 2.91 0 0 0-2.894-3.214h-.364c-.5 0-.928.357-1.017.849l-.055.303a4.989 4.989 0 0 1-1.915 3.098h-2c-.69 0-1.25.56-1.25 1.25v5.5c0 .69.56 1.25 1.25 1.25h2.345c.324 0 .644.07.938.205l.307.14Z" />
                     </svg>
                     <div style="flex: 1; height: 7px; border-radius: 4px; background: #f5f5f5; overflow: hidden">
-                      <div style="width: 35%; height: 100%; border-radius: 4px; background: #111"></div>
+                      <div style="width: 35%; height: 100%; border-radius: 4px; background: #1d1d20"></div>
                     </div>
                     <span style="font-size: 13px; font-weight: 500; color: #555; min-width: 32px; text-align: right"
                       >96</span
                     >
                   </div>
                   <div style="display: flex; align-items: center; gap: 10px">
-                    <svg viewBox="0 0 20 20" width="18" height="18" style="flex-shrink: 0; color: #929292">
+                    <svg viewBox="0 0 20 20" width="18" height="18" style="flex-shrink: 0; color: #666c77">
                       <path
                         fill="currentColor"
                         d="M10 2c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8Zm0 14.4c-3.5 0-6.4-2.9-6.4-6.4S6.5 3.6 10 3.6s6.4 2.9 6.4 6.4-2.9 6.4-6.4 6.4ZM7.6 9.2c.4 0 .8-.4.8-.8s-.4-.8-.8-.8-.8.4-.8.8.4.8.8.8Zm4.8-1.6c-.4 0-.8.4-.8.8s.4.8.8.8.8-.4.8-.8-.4-.8-.8-.8Zm0 4H7.6c-.4 0-.8.4-.8.8s.4.8.8.8h4.8c.4 0 .8-.4.8-.8s-.4-.8-.8-.8Z" />
                     </svg>
                     <div style="flex: 1; height: 7px; border-radius: 4px; background: #f5f5f5; overflow: hidden">
-                      <div style="width: 24%; height: 100%; border-radius: 4px; background: #111"></div>
+                      <div style="width: 24%; height: 100%; border-radius: 4px; background: #1d1d20"></div>
                     </div>
                     <span style="font-size: 13px; font-weight: 500; color: #555; min-width: 32px; text-align: right"
                       >66</span
                     >
                   </div>
                   <div style="display: flex; align-items: center; gap: 10px">
-                    <svg viewBox="0 0 20 20" width="18" height="18" style="flex-shrink: 0; color: #ef4444">
+                    <svg viewBox="0 0 20 20" width="18" height="18" style="flex-shrink: 0; color: #c5342e">
                       <path
                         fill-rule="evenodd"
                         fill="currentColor"
                         d="M12.16 4.904a10.75 10.75 0 0 0-4.735-.974l-.391.01a3.75 3.75 0 0 0-3.626 3.236l-.337 2.448a2.75 2.75 0 0 0 2.724 3.126h1.594a.25.25 0 0 1 .249.276l-.133 1.26a2.91 2.91 0 0 0 2.894 3.214h.364c.5 0 .928-.358 1.017-.85l.055-.302a4.989 4.989 0 0 1 1.915-3.098h2c.69 0 1.25-.56 1.25-1.25v-5.5c0-.69-.56-1.25-1.25-1.25h-2.345a2.25 2.25 0 0 1-.938-.205l-.307-.14Zm-4.699.525a9.25 9.25 0 0 1 4.074.839l.307.14a3.75 3.75 0 0 0 1.158.32v5.223c-.052.03-.102.062-.15.098a6.49 6.49 0 0 0-2.475 3.95 1.41 1.41 0 0 1-1.378-1.557l.133-1.26a1.75 1.75 0 0 0-1.74-1.932h-1.595a1.25 1.25 0 0 1-1.238-1.421l.337-2.448a2.25 2.25 0 0 1 2.176-1.942l.391-.01Zm7.039 6.32h1v-5h-1v5Z" />
                     </svg>
                     <div style="flex: 1; height: 7px; border-radius: 4px; background: #f5f5f5; overflow: hidden">
-                      <div style="width: 40%; height: 100%; border-radius: 4px; background: #111"></div>
+                      <div style="width: 40%; height: 100%; border-radius: 4px; background: #1d1d20"></div>
                     </div>
                     <span style="font-size: 13px; font-weight: 500; color: #555; min-width: 32px; text-align: right"
                       >110</span
@@ -2028,19 +2079,19 @@
                   border-bottom: 1px solid #f5f5f5;
                 ">
                 <div>
-                  <span style="font-size: 11px; color: #999; font-weight: 500">Total</span>
+                  <span style="font-size: 11px; color: #666c77; font-weight: 500">Total</span>
                   <span style="font-size: 13px; font-weight: 700; color: #222; margin-left: 2px">108</span>
                 </div>
                 <div>
-                  <span style="font-size: 11px; color: #999; font-weight: 500">Unique</span>
+                  <span style="font-size: 11px; color: #666c77; font-weight: 500">Unique</span>
                   <span style="font-size: 13px; font-weight: 700; color: #222; margin-left: 2px">36</span>
                 </div>
                 <div>
-                  <span style="font-size: 11px; color: #999; font-weight: 500">Internal</span>
+                  <span style="font-size: 11px; color: #666c77; font-weight: 500">Internal</span>
                   <span style="font-size: 13px; font-weight: 700; color: #222; margin-left: 2px">97</span>
                 </div>
                 <div>
-                  <span style="font-size: 11px; color: #999; font-weight: 500">External</span>
+                  <span style="font-size: 11px; color: #666c77; font-weight: 500">External</span>
                   <span style="font-size: 13px; font-weight: 700; color: #222; margin-left: 2px">11</span>
                 </div>
               </div>
@@ -2115,7 +2166,7 @@
                   </tr>
                 </tbody>
               </table>
-              <div style="margin-top: 8px; font-size: 11px; color: #ccc">Showing 5 of 108 links</div>
+              <div style="margin-top: 8px; font-size: 11px; color: #666c77">Showing 5 of 108 links</div>
             </div>
           </div>
 
@@ -2156,7 +2207,7 @@
             <div class="content-pad">
               <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px">
                 <div style="font-size: 15px; font-weight: 600; color: #222">
-                  Images <span style="font-weight: 400; color: #999">25</span>
+                  Images <span style="font-weight: 400; color: #666c77">25</span>
                 </div>
                 <div class="action-btns">
                   <button class="action-btn">
@@ -2191,7 +2242,7 @@
                     border-radius: 6px;
                     border: 1px solid #ebebeb;
                     background: #fff
-                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
+                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23666c77%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
                       no-repeat right 6px center;
                     appearance: none;
                     color: #555;
@@ -2209,7 +2260,7 @@
                     border-radius: 6px;
                     border: 1px solid #ebebeb;
                     background: #fff
-                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
+                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23666c77%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
                       no-repeat right 6px center;
                     appearance: none;
                     color: #555;
@@ -2229,7 +2280,7 @@
                     border-radius: 6px;
                     border: 1px solid #ebebeb;
                     background: #fff
-                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
+                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23666c77%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
                       no-repeat right 6px center;
                     appearance: none;
                     color: #555;
@@ -2248,7 +2299,7 @@
                     border-radius: 6px;
                     border: 1px solid #ebebeb;
                     background: #fff
-                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
+                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23666c77%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
                       no-repeat right 6px center;
                     appearance: none;
                     color: #555;
@@ -2269,7 +2320,7 @@
                         text-align: left;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 0;
@@ -2283,7 +2334,7 @@
                         text-align: right;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 4px;
@@ -2297,7 +2348,7 @@
                         text-align: center;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 4px;
@@ -2311,7 +2362,7 @@
                         text-align: center;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 4px;
@@ -2325,7 +2376,7 @@
                         text-align: center;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 4px;
@@ -2339,7 +2390,7 @@
                         text-align: center;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 0;
@@ -2376,7 +2427,7 @@
                             href="#"
                             style="
                               font-size: 10.5px;
-                              color: #7c3aed;
+                              color: #4f57c4;
                               text-decoration: none;
                               font-family: ui-monospace, monospace;
                               word-break: break-all;
@@ -2427,7 +2478,7 @@
                         text-align: center;
                         vertical-align: top;
                       ">
-                      <span style="color: #d97706; font-weight: 500">eager</span>
+                      <span style="color: #9c4a08; font-weight: 500">eager</span>
                     </td>
                     <td
                       style="
@@ -2467,7 +2518,7 @@
                             href="#"
                             style="
                               font-size: 10.5px;
-                              color: #7c3aed;
+                              color: #4f57c4;
                               text-decoration: none;
                               font-family: ui-monospace, monospace;
                               word-break: break-all;
@@ -2559,7 +2610,7 @@
                             href="#"
                             style="
                               font-size: 10.5px;
-                              color: #7c3aed;
+                              color: #4f57c4;
                               text-decoration: none;
                               font-family: ui-monospace, monospace;
                               word-break: break-all;
@@ -2635,12 +2686,12 @@
                             flex-shrink: 0;
                           "></div>
                         <div style="min-width: 0">
-                          <div style="font-size: 12px; color: #e25555; font-weight: 500">Missing alt text</div>
+                          <div style="font-size: 12px; color: #c5342e; font-weight: 500">Missing alt text</div>
                           <a
                             href="#"
                             style="
                               font-size: 10.5px;
-                              color: #7c3aed;
+                              color: #4f57c4;
                               text-decoration: none;
                               font-family: ui-monospace, monospace;
                               word-break: break-all;
@@ -2716,12 +2767,12 @@
                             flex-shrink: 0;
                           "></div>
                         <div style="min-width: 0">
-                          <div style="font-size: 12px; color: #e25555; font-weight: 500">Missing alt text</div>
+                          <div style="font-size: 12px; color: #c5342e; font-weight: 500">Missing alt text</div>
                           <a
                             href="#"
                             style="
                               font-size: 10.5px;
-                              color: #7c3aed;
+                              color: #4f57c4;
                               text-decoration: none;
                               font-family: ui-monospace, monospace;
                               word-break: break-all;
@@ -2761,7 +2812,7 @@
                   </tr>
                 </tbody>
               </table>
-              <div style="margin-top: 8px; font-size: 11px; color: #999">Showing 5 of 25 images</div>
+              <div style="margin-top: 8px; font-size: 11px; color: #666c77">Showing 5 of 25 images</div>
             </div>
           </div>
 
@@ -2832,7 +2883,7 @@
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -2851,7 +2902,7 @@
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -2870,7 +2921,7 @@
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -2886,7 +2937,7 @@
                         <a
                           href="#"
                           style="
-                            color: #7c3aed;
+                            color: #4f57c4;
                             text-decoration: none;
                             font-family: ui-monospace, monospace;
                             font-size: 12px;
@@ -2914,13 +2965,13 @@
                             DAWN
                           </div>
                         </div>
-                        <div style="font-size: 11px; color: #999; margin-top: 6px">1200 x 628px &nbsp; 7.52 KB</div>
+                        <div style="font-size: 11px; color: #666c77; margin-top: 6px">1200 x 628px &nbsp; 7.52 KB</div>
                       </td>
                     </tr>
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -2939,7 +2990,7 @@
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -2958,7 +3009,7 @@
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -2977,7 +3028,7 @@
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -2992,7 +3043,7 @@
                         <a
                           href="#"
                           style="
-                            color: #7c3aed;
+                            color: #4f57c4;
                             text-decoration: none;
                             font-family: ui-monospace, monospace;
                             font-size: 12px;
@@ -3025,7 +3076,7 @@
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -3037,14 +3088,14 @@
                         ">
                         twitter:card
                       </td>
-                      <td style="font-size: 13px; color: #999; padding: 7px 0; border-bottom: 1px solid #f8f8f8">
+                      <td style="font-size: 13px; color: #666c77; padding: 7px 0; border-bottom: 1px solid #f8f8f8">
                         Not specified
                       </td>
                     </tr>
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -3056,14 +3107,14 @@
                         ">
                         twitter:title
                       </td>
-                      <td style="font-size: 13px; color: #999; padding: 7px 0; border-bottom: 1px solid #f8f8f8">
+                      <td style="font-size: 13px; color: #666c77; padding: 7px 0; border-bottom: 1px solid #f8f8f8">
                         Not specified
                       </td>
                     </tr>
                     <tr>
                       <td
                         style="
-                          color: #999;
+                          color: #666c77;
                           font-family: ui-monospace, monospace;
                           font-size: 12px;
                           padding: 7px 12px 7px 20px;
@@ -3074,7 +3125,7 @@
                         ">
                         twitter:description
                       </td>
-                      <td style="font-size: 13px; color: #999; padding: 7px 0">Not specified</td>
+                      <td style="font-size: 13px; color: #666c77; padding: 7px 0">Not specified</td>
                     </tr>
                   </tbody>
                 </table>
@@ -3088,7 +3139,7 @@
               <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px">
                 <div>
                   <div style="font-size: 15px; font-weight: 600; color: #222">5 apps detected</div>
-                  <div style="font-size: 12px; color: #999; margin-top: 2px">on theme-dawn-demo.myshopify.com</div>
+                  <div style="font-size: 12px; color: #666c77; margin-top: 2px">on theme-dawn-demo.myshopify.com</div>
                 </div>
                 <button class="action-btn">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" aria-hidden="true">
@@ -3148,7 +3199,7 @@
                 <span class="pill pill-gray" style="font-size: 10px">Sales</span>
               </div>
               <div class="app-card">
-                <div class="app-icon" style="background: #7c3aed">
+                <div class="app-icon" style="background: #4f57c4">
                   <svg viewBox="0 0 20 20" width="16" height="16" fill="#FFF">
                     <circle cx="10" cy="10" r="3" />
                     <path
@@ -3163,7 +3214,7 @@
               </div>
 
               <div class="section-heading" style="margin-top: 6px">Unrecognized Scripts (2)</div>
-              <div style="font-size: 12px; color: #999; margin-bottom: 10px">
+              <div style="font-size: 12px; color: #666c77; margin-bottom: 10px">
                 Scripts loaded on this page that don't match known apps
               </div>
               <div class="row" style="gap: 8px">
@@ -3171,7 +3222,7 @@
                   style="
                     font-family: ui-monospace, monospace;
                     font-size: 11px;
-                    color: #777;
+                    color: #666c77;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
@@ -3185,7 +3236,7 @@
                   style="
                     font-family: ui-monospace, monospace;
                     font-size: 11px;
-                    color: #777;
+                    color: #666c77;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
@@ -3202,7 +3253,7 @@
             <div class="content-pad">
               <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px">
                 <div style="font-size: 15px; font-weight: 600; color: #222">
-                  Products <span style="font-weight: 400; color: #999">32</span>
+                  Products <span style="font-weight: 400; color: #666c77">32</span>
                 </div>
                 <div class="action-btns">
                   <button class="action-btn">
@@ -3227,19 +3278,19 @@
                   border-bottom: 1px solid #f5f5f5;
                 ">
                 <div>
-                  <span style="font-size: 11px; color: #999; font-weight: 500">Avg Price</span>
+                  <span style="font-size: 11px; color: #666c77; font-weight: 500">Avg Price</span>
                   <span style="font-size: 13px; font-weight: 700; color: #222; margin-left: 2px">$432</span>
                 </div>
                 <div>
-                  <span style="font-size: 11px; color: #999; font-weight: 500">Highest</span>
+                  <span style="font-size: 11px; color: #666c77; font-weight: 500">Highest</span>
                   <span style="font-size: 13px; font-weight: 700; color: #222; margin-left: 2px">$615</span>
                 </div>
                 <div>
-                  <span style="font-size: 11px; color: #999; font-weight: 500">Lowest</span>
+                  <span style="font-size: 11px; color: #666c77; font-weight: 500">Lowest</span>
                   <span style="font-size: 13px; font-weight: 700; color: #222; margin-left: 2px">$119</span>
                 </div>
                 <div>
-                  <span style="font-size: 11px; color: #999; font-weight: 500">Published</span>
+                  <span style="font-size: 11px; color: #666c77; font-weight: 500">Published</span>
                   <span style="font-size: 13px; font-weight: 700; color: #222; margin-left: 2px">Nov 2021</span>
                 </div>
               </div>
@@ -3253,7 +3304,7 @@
                     border-radius: 6px;
                     border: 1px solid #ebebeb;
                     background: #fff
-                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
+                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23666c77%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
                       no-repeat right 6px center;
                     appearance: none;
                     color: #555;
@@ -3273,7 +3324,7 @@
                     border-radius: 6px;
                     border: 1px solid #ebebeb;
                     background: #fff
-                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
+                      url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%2212%22 viewBox=%220 0 24 24%22 fill=%22none%22 stroke=%22%23666c77%22 stroke-width=%222%22><path d=%22M6 9l6 6 6-6%22/></svg>')
                       no-repeat right 6px center;
                     appearance: none;
                     color: #555;
@@ -3293,7 +3344,7 @@
                         text-align: left;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 0;
@@ -3306,7 +3357,7 @@
                         text-align: right;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 4px;
@@ -3320,7 +3371,7 @@
                         text-align: center;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 4px;
@@ -3334,7 +3385,7 @@
                         text-align: center;
                         font-size: 10px;
                         font-weight: 600;
-                        color: #999;
+                        color: #666c77;
                         text-transform: uppercase;
                         letter-spacing: 0.04em;
                         padding: 6px 0;
@@ -3365,7 +3416,7 @@
                           "></div>
                         <div style="min-width: 0">
                           <div style="font-size: 12px; color: #333; font-weight: 500">Small Convertible Flex Bag</div>
-                          <div style="font-size: 10.5px; color: #999; margin-top: 1px">Cappuccino</div>
+                          <div style="font-size: 10.5px; color: #666c77; margin-top: 1px">Cappuccino</div>
                         </div>
                       </div>
                     </td>
@@ -3555,7 +3606,7 @@
                           "></div>
                         <div style="min-width: 0">
                           <div style="font-size: 12px; color: #333; font-weight: 500">Studio Bag</div>
-                          <div style="font-size: 10.5px; color: #999; margin-top: 1px">Denim</div>
+                          <div style="font-size: 10.5px; color: #666c77; margin-top: 1px">Denim</div>
                         </div>
                       </div>
                     </td>
@@ -3701,7 +3752,7 @@
                           "></div>
                         <div style="min-width: 0">
                           <div style="font-size: 12px; color: #333; font-weight: 500">Louise Slide Sandal</div>
-                          <div style="font-size: 10.5px; color: #999; margin-top: 1px">Buttermilk</div>
+                          <div style="font-size: 10.5px; color: #666c77; margin-top: 1px">Buttermilk</div>
                         </div>
                       </div>
                     </td>
@@ -3901,7 +3952,7 @@
                             style="
                               padding: 7px 4px;
                               text-align: right;
-                              color: #e25555;
+                              color: #c5342e;
                               font-weight: 500;
                               vertical-align: top;
                             ">
@@ -3929,7 +3980,7 @@
                           "></div>
                         <div style="min-width: 0">
                           <div style="font-size: 12px; color: #333; font-weight: 500">Bo Ivy</div>
-                          <div style="font-size: 10.5px; color: #999; margin-top: 1px">Black</div>
+                          <div style="font-size: 10.5px; color: #666c77; margin-top: 1px">Black</div>
                         </div>
                       </div>
                     </td>
@@ -3984,7 +4035,7 @@
                           "></div>
                         <div style="min-width: 0">
                           <div style="font-size: 12px; color: #333; font-weight: 500">Brick</div>
-                          <div style="font-size: 10.5px; color: #999; margin-top: 1px">Apple</div>
+                          <div style="font-size: 10.5px; color: #666c77; margin-top: 1px">Apple</div>
                         </div>
                       </div>
                     </td>
@@ -4092,7 +4143,7 @@
                   </tr>
                 </tbody>
               </table>
-              <div style="margin-top: 8px; font-size: 11px; color: #999">Showing 5 of 32 products</div>
+              <div style="margin-top: 8px; font-size: 11px; color: #666c77">Showing 5 of 32 products</div>
             </div>
           </div>
 
@@ -4105,7 +4156,7 @@
                   <div style="font-size: 15px; font-weight: 600; color: #222">robots.txt</div>
                   <a
                     href="#"
-                    style="font-size: 12px; color: #7c3aed; text-decoration: none; font-family: ui-monospace, monospace"
+                    style="font-size: 12px; color: #4f57c4; text-decoration: none; font-family: ui-monospace, monospace"
                     >theme-dawn-demo.myshopify.com/robots.txt</a
                   >
                 </div>
@@ -4148,7 +4199,7 @@
                   word-break: break-all;
                   max-height: 340px;
                   overflow-y: auto;
-                "><span style="color:#999"># we use Shopify's default robots.txt</span>
+                "><span style="color:#666c77"># we use Shopify's default robots.txt</span>
 <span style="color:#222;font-weight:600">User-agent: *</span>
 Disallow: /admin
 Disallow: /cart
@@ -4175,7 +4226,7 @@ Disallow: /search
 Disallow: /*/search
 Disallow: /apple-app-site-association
 
-<span style="color:#222;font-weight:600">Sitemap:</span> <a href="#" style="color:#7C3AED;text-decoration:none">https://theme-dawn-demo.myshopify.com/sitemap.xml</a></pre>
+<span style="color:#222;font-weight:600">Sitemap:</span> <a href="#" style="color:#4f57c4;text-decoration:none">https://theme-dawn-demo.myshopify.com/sitemap.xml</a></pre>
             </div>
           </div>
 
@@ -4185,7 +4236,7 @@ Disallow: /apple-app-site-association
               <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px">
                 <div>
                   <div style="font-size: 15px; font-weight: 600; color: #222">Sitemaps</div>
-                  <div style="font-size: 12px; color: #999; margin-top: 2px">5 sitemaps found</div>
+                  <div style="font-size: 12px; color: #666c77; margin-top: 2px">5 sitemaps found</div>
                 </div>
                 <button class="action-btn" onclick="window.open('#')">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" aria-hidden="true">
@@ -4200,7 +4251,7 @@ Disallow: /apple-app-site-association
                   <div class="app-name" style="font-size: 12px">sitemap_agentic_discovery.xml</div>
                   <a
                     href="#"
-                    style="font-size: 11px; color: #7c3aed; text-decoration: none; font-family: ui-monospace, monospace"
+                    style="font-size: 11px; color: #4f57c4; text-decoration: none; font-family: ui-monospace, monospace"
                     >.../sitemap_agentic_discovery.xml</a
                   >
                 </div>
@@ -4212,7 +4263,7 @@ Disallow: /apple-app-site-association
                   <div class="app-name" style="font-size: 12px">sitemap_products_1.xml</div>
                   <a
                     href="#"
-                    style="font-size: 11px; color: #7c3aed; text-decoration: none; font-family: ui-monospace, monospace"
+                    style="font-size: 11px; color: #4f57c4; text-decoration: none; font-family: ui-monospace, monospace"
                     >.../sitemap_products_1.xml</a
                   >
                 </div>
@@ -4224,7 +4275,7 @@ Disallow: /apple-app-site-association
                   <div class="app-name" style="font-size: 12px">sitemap_pages_1.xml</div>
                   <a
                     href="#"
-                    style="font-size: 11px; color: #7c3aed; text-decoration: none; font-family: ui-monospace, monospace"
+                    style="font-size: 11px; color: #4f57c4; text-decoration: none; font-family: ui-monospace, monospace"
                     >.../sitemap_pages_1.xml</a
                   >
                 </div>
@@ -4236,7 +4287,7 @@ Disallow: /apple-app-site-association
                   <div class="app-name" style="font-size: 12px">sitemap_collections_1.xml</div>
                   <a
                     href="#"
-                    style="font-size: 11px; color: #7c3aed; text-decoration: none; font-family: ui-monospace, monospace"
+                    style="font-size: 11px; color: #4f57c4; text-decoration: none; font-family: ui-monospace, monospace"
                     >.../sitemap_collections_1.xml</a
                   >
                 </div>
@@ -4248,7 +4299,7 @@ Disallow: /apple-app-site-association
                   <div class="app-name" style="font-size: 12px">sitemap_blogs_1.xml</div>
                   <a
                     href="#"
-                    style="font-size: 11px; color: #7c3aed; text-decoration: none; font-family: ui-monospace, monospace"
+                    style="font-size: 11px; color: #4f57c4; text-decoration: none; font-family: ui-monospace, monospace"
                     >.../sitemap_blogs_1.xml</a
                   >
                 </div>

--- a/designs/popup-preview.html
+++ b/designs/popup-preview.html
@@ -1,0 +1,2147 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Alfred Popup - real-CSS preview</title>
+    <style>
+      /* ============================================================
+         TOKENS - mirrors entrypoints/popup/index.html :root
+         Corrected role-preserving palette (indigo accent, AA, one
+         elevation rule, semantic green reserved for brand/success).
+         ============================================================ */
+      :root {
+        /* Surfaces: sidebar recedes < canvas < cards lift; insets recede */
+        --bg: #ffffff; /* cards, active tab, inputs, dropdowns */
+        --bg-canvas: #fbfcfd; /* popup + content base (soft off-white) */
+        --bg-raised: #f4f6f8; /* sidebar / footers / code (recede) */
+        --bg-inset: #eef1f5; /* wells: chips, tracks, h5/h6 badges */
+        --bg-hover: #e9edf3; /* row / tab hover */
+
+        /* Borders */
+        --border: #e9eaef;
+        --border-subtle: #eef0f3;
+        --border-muted: #f2f3f6;
+        --border-hover: #ccd0d8;
+        --border-strong: #dadde3;
+
+        /* Text - distinct, ordered, AA (faint = decorative tier only) */
+        --text: #1d1d22;
+        --text-secondary: #4d515b;
+        --text-muted: #656b78;
+        --text-faint: #828892;
+        --text-disabled: #b3b8c0;
+        --text-placeholder: #8b909b;
+
+        /* Interactive (sidebar tabs = muted gray) */
+        --text-link: #656b78;
+        --text-link-hover: #3a3e47;
+        --text-link-muted: #656b78;
+        --text-link-muted-hover: #4d515b;
+        --text-label: #656b78;
+
+        /* Accent: calm desaturated indigo = interactive role */
+        --accent: #4f57c4;
+        --accent-strong: #3f47b3;
+        --accent-tint: #eef0fb;
+
+        /* Buttons */
+        --btn-bg: #1d1d22;
+        --btn-bg-hover: #34343c;
+        --btn-text: #ffffff;
+
+        /* Semantic (green = brand/success, AA on tint) */
+        --success: #1a9d51;
+        --success-strong: #15783f;
+        --success-bg: #e7f5ec;
+        --warning: #9a5a08;
+        --warning-bg: #f9f0db;
+        --error: #c8362f;
+        --error-strong: #b42f28;
+        --error-bg: #fcebe9;
+
+        /* Misc */
+        --star-active: #fbbf24;
+        --star-inactive: #e2e4e9;
+        --scrollbar: #d2d5dd;
+        --ring: 0 0 0 3px rgba(79, 87, 196, 0.28);
+
+        /* Shadows: cool-tinted, soft */
+        --shadow-sm: 0 1px 2px rgba(28, 28, 46, 0.05);
+        --shadow-md: 0 2px 8px rgba(28, 28, 46, 0.04);
+        --shadow-tab: 0 1px 2px rgba(28, 28, 46, 0.06), 0 0 0 1px rgba(28, 28, 46, 0.04);
+        --shadow-knob: 0 1px 3px rgba(28, 28, 46, 0.16);
+        --shadow-pop: 0 6px 20px rgba(28, 28, 46, 0.1);
+
+        /* Gradient: subtle cool, lighter than the old gray band */
+        --hero-gradient: linear-gradient(135deg, #f3f5f8 0%, #eef1f6 55%, #f5f7f9 100%);
+      }
+
+      /* NOTE: the real popup has no global box-sizing reset; mirror that so
+         the preview stays faithful (components set box-sizing where needed). */
+      * {
+        margin: 0;
+        padding: 0;
+      }
+      html,
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        background: #e8e8e8;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+      }
+      :focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.001ms !important;
+          animation-delay: 0ms !important;
+          transition-duration: 0.001ms !important;
+        }
+      }
+
+      /* ============================ App shell ============================ */
+      .popup {
+        width: 790px;
+        height: 550px;
+        background: var(--bg-canvas);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        border-radius: 12px;
+        box-shadow: 0 10px 40px rgba(28, 28, 46, 0.12);
+      }
+      .brand {
+        padding: 10px 16px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        border-bottom: 1px solid var(--border);
+        flex-shrink: 0;
+      }
+      .brand__name {
+        font-size: 14px;
+        font-weight: 700;
+        color: var(--text);
+        letter-spacing: -0.01em;
+      }
+      .layout {
+        display: flex;
+        flex: 1;
+        min-height: 0;
+      }
+      .sidebar {
+        width: 192px;
+        background: var(--bg-raised);
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        padding: 4px 0;
+        flex-shrink: 0;
+        overflow-y: auto;
+      }
+      .sidebar__label {
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--text-label);
+        padding: 10px 14px 3px;
+        display: flex;
+        align-items: center;
+      }
+      .sidebar__label:first-child {
+        padding-top: 8px;
+        padding-bottom: 6px;
+      }
+      .sidebar__divider {
+        height: 1px;
+        background: var(--border-strong);
+        margin: 5px 14px;
+      }
+      .sidebar__bottom {
+        margin-top: auto;
+        border-top: 1px solid var(--border);
+        padding-top: 2px;
+      }
+      .sidebar__suggest {
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        padding: 6px 10px;
+        margin: 1px 6px;
+        border-radius: 7px;
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--text-link-muted);
+        text-decoration: none;
+        transition: all 0.12s;
+      }
+      .sidebar__suggest:hover {
+        color: var(--text-link-muted-hover);
+        background: var(--bg-hover);
+      }
+      .sidebar__suggest svg {
+        width: 14px;
+        height: 14px;
+        opacity: 0.4;
+        stroke-width: 1.7;
+      }
+      .tab {
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        padding: 7px 10px;
+        margin: 1px 6px;
+        border-radius: 7px;
+        font-size: 13.5px;
+        font-weight: 500;
+        color: var(--text-link);
+        cursor: pointer;
+        border: none;
+        background: none;
+        width: calc(100% - 12px);
+        text-align: left;
+        transition: all 0.12s ease;
+        font-family: inherit;
+      }
+      .tab:hover {
+        background: var(--bg-hover);
+        color: var(--text-link-hover);
+      }
+      .tab.active {
+        background: var(--bg);
+        color: var(--text);
+        font-weight: 600;
+        box-shadow: var(--shadow-tab);
+      }
+      .tab svg {
+        width: 15px;
+        height: 15px;
+        flex-shrink: 0;
+        opacity: 0.5;
+        stroke-width: 1.8;
+      }
+      .tab.active svg {
+        opacity: 0.9;
+      }
+      .tab__badge {
+        margin-left: auto;
+        font-size: 10px;
+        font-weight: 600;
+        padding: 0px 5px;
+        border-radius: 8px;
+        min-width: 16px;
+        text-align: center;
+        line-height: 16px;
+      }
+      .tab__badge--red {
+        background: var(--error-bg);
+        color: var(--error-strong);
+      }
+      .content {
+        flex: 1;
+        overflow-y: auto;
+        overflow-x: hidden;
+        background: var(--bg-canvas);
+        scrollbar-gutter: stable;
+      }
+      .content::-webkit-scrollbar,
+      .sidebar::-webkit-scrollbar {
+        width: 3px;
+      }
+      .content::-webkit-scrollbar-thumb,
+      .sidebar::-webkit-scrollbar-thumb {
+        background: var(--scrollbar);
+        border-radius: 3px;
+      }
+      .content__pad {
+        padding: 24px 28px 28px;
+      }
+      .panel {
+        display: none;
+      }
+      .panel.active {
+        display: block;
+      }
+      .panel--flex.active {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+
+      /* review prompt (compact, brand bar) */
+      .prompt--compact {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .prompt__label {
+        font-size: 12px;
+        color: var(--text-link-muted);
+      }
+      .prompt__stars {
+        display: flex;
+        gap: 1px;
+      }
+      .prompt__star {
+        background: none;
+        border: none;
+        padding: 1px;
+        cursor: pointer;
+        line-height: 0;
+        border-radius: 3px;
+      }
+      .prompt__svg {
+        width: 16px;
+        height: 16px;
+      }
+
+      /* ============================ Theme ============================ */
+      .hero {
+        padding: 32px 32px 0;
+        position: relative;
+      }
+      .hero::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 140px;
+        background: var(--hero-gradient);
+        border-bottom: 1px solid var(--border);
+      }
+      .hero__identity {
+        position: relative;
+        display: flex;
+        align-items: flex-end;
+        gap: 20px;
+        padding-bottom: 24px;
+      }
+      .hero__meta {
+        flex: 1;
+        min-width: 0;
+        padding-bottom: 2px;
+      }
+      .hero__name {
+        font-size: 24px;
+        font-weight: 600;
+        color: var(--text);
+        letter-spacing: -0.02em;
+        line-height: 1.15;
+        margin: 0;
+      }
+      .hero__byline {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-top: 5px;
+        font-size: 12.5px;
+        color: var(--text-muted);
+      }
+      .hero__byline-dot {
+        width: 3px;
+        height: 3px;
+        border-radius: 50%;
+        background: var(--text-muted);
+        opacity: 0.5;
+      }
+      .hero__developer-link {
+        color: var(--text-secondary);
+        text-decoration: underline;
+        text-decoration-color: var(--text-muted);
+        text-underline-offset: 2px;
+      }
+      .hero__store-url {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        margin-top: 4px;
+      }
+      .hero__store-domain {
+        font-family: 'SF Mono', ui-monospace, monospace;
+        font-size: 11.5px;
+        color: var(--text-muted);
+      }
+      .hero__actions {
+        display: flex;
+        gap: 6px;
+        flex-shrink: 0;
+        padding-bottom: 4px;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        border-radius: 6px;
+        cursor: pointer;
+        text-decoration: none;
+        transition: all 0.12s;
+        font-family: inherit;
+      }
+      .btn--ghost {
+        padding: 6px 12px;
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--text-secondary);
+        background: var(--bg);
+        border: 1px solid var(--border);
+      }
+      .btn--ghost:hover {
+        border-color: var(--border-hover);
+        color: var(--text);
+        box-shadow: var(--shadow-sm);
+      }
+      .btn--ghost svg {
+        width: 13px;
+        height: 13px;
+        stroke-width: 1.7;
+      }
+      .btn--primary {
+        padding: 6px 14px;
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--btn-text);
+        background: var(--btn-bg);
+        border: none;
+      }
+      .btn--primary:hover {
+        background: var(--btn-bg-hover);
+      }
+      .btn--primary svg {
+        width: 12px;
+        height: 12px;
+        stroke-width: 2;
+      }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1px;
+        background: var(--border);
+        border-radius: 10px;
+        margin: 0 32px;
+        box-shadow:
+          0 0 0 1px var(--border),
+          var(--shadow-md);
+      }
+      .stats__cell {
+        background: var(--bg);
+        padding: 16px 18px;
+      }
+      .stats__cell:first-child {
+        border-radius: 10px 0 0 10px;
+      }
+      .stats__cell:last-child {
+        border-radius: 0 10px 10px 0;
+      }
+      .stats__label {
+        font-size: 11px;
+        font-weight: 500;
+        color: var(--text-muted);
+        letter-spacing: 0.02em;
+      }
+      .stats__value {
+        font-size: 17px;
+        font-weight: 600;
+        color: var(--text);
+        margin-top: 3px;
+        letter-spacing: -0.02em;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .stats__code {
+        font-family: 'SF Mono', ui-monospace, monospace;
+        font-size: 13px;
+        font-weight: 500;
+      }
+      .stats__update {
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+        font-size: 10.5px;
+        font-weight: 600;
+        padding: 2px 7px;
+        border-radius: 20px;
+        background: var(--success-bg);
+        color: var(--success-strong);
+        white-space: nowrap;
+      }
+      .stats__status-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+      .copy-trigger {
+        width: 16px;
+        height: 16px;
+        color: var(--text-placeholder);
+        cursor: pointer;
+      }
+      .copy-trigger:hover {
+        color: var(--text-muted);
+      }
+      .sections {
+        padding: 24px 32px 32px;
+      }
+      .section {
+        margin-bottom: 24px;
+      }
+      .section__title {
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--text-muted);
+        margin-bottom: 12px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .section__title::after {
+        content: '';
+        flex: 1;
+        height: 1px;
+        background: var(--border);
+      }
+      .internal-name {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 16px;
+        background: var(--bg-inset);
+        border-radius: 10px;
+        border: 1px dashed var(--border);
+      }
+      .internal-name__label {
+        font-size: 10.5px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--text-muted);
+        white-space: nowrap;
+      }
+      .internal-name__value {
+        font-family: 'SF Mono', ui-monospace, monospace;
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--text);
+        letter-spacing: -0.01em;
+      }
+      .preview {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        overflow: hidden;
+      }
+      .preview__url {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 14px;
+      }
+      .preview__icon {
+        width: 14px;
+        height: 14px;
+        flex-shrink: 0;
+        color: var(--text-muted);
+      }
+      .preview__input {
+        flex: 1;
+        border: none;
+        background: none;
+        font-family: 'SF Mono', ui-monospace, monospace;
+        font-size: 12px;
+        color: var(--text-secondary);
+        outline: none;
+        min-width: 0;
+      }
+      .preview__copy {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 0 8px;
+        height: 28px;
+        font-size: 11px;
+        font-weight: 600;
+        flex-shrink: 0;
+        border-radius: 6px;
+      }
+      .preview__copy svg {
+        width: 13px;
+        height: 13px;
+        stroke-width: 1.8;
+      }
+      .preview__footer {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        padding: 8px 14px;
+        border-top: 1px solid var(--border-subtle);
+        background: var(--bg-raised);
+      }
+      .toggle {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        cursor: pointer;
+      }
+      .toggle__track {
+        width: 28px;
+        height: 16px;
+        background: var(--bg-hover);
+        border-radius: 8px;
+        position: relative;
+        transition: background 0.2s;
+        flex-shrink: 0;
+      }
+      .toggle__track.on {
+        background: var(--accent);
+      }
+      .toggle__knob {
+        width: 12px;
+        height: 12px;
+        background: var(--bg);
+        border-radius: 50%;
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        transition: transform 0.15s;
+        box-shadow: var(--shadow-knob);
+      }
+      .toggle__track.on .toggle__knob {
+        transform: translateX(12px);
+      }
+      .toggle__text {
+        font-size: 11.5px;
+        color: var(--text-muted);
+        font-weight: 450;
+      }
+
+      /* ============================ Headings ============================ */
+      .headings {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+      .statusbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 20px;
+        border-bottom: 1px solid var(--border);
+        flex-shrink: 0;
+      }
+      .counts {
+        display: flex;
+        gap: 2px;
+      }
+      .counts__item {
+        display: flex;
+        align-items: center;
+        gap: 3px;
+        padding: 0 8px;
+        height: 28px;
+        border-radius: 6px;
+        background: var(--bg-inset);
+      }
+      .counts__item--zero {
+        opacity: 0.4;
+      }
+      .counts__label {
+        font-family: 'SF Mono', ui-monospace, monospace;
+        font-size: 10px;
+        font-weight: 600;
+        color: var(--text-muted);
+      }
+      .counts__value {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text);
+      }
+      .counts__item--zero .counts__value {
+        color: var(--text-muted);
+      }
+      .statusbar__actions {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .filter {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 0 8px;
+        height: 28px;
+        border-radius: 6px;
+        border: 1px solid var(--border-strong);
+        background: var(--bg);
+        font-family: inherit;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-muted);
+        cursor: pointer;
+      }
+      .filter:hover {
+        border-color: var(--border-hover);
+        color: var(--text-secondary);
+      }
+      .filter svg {
+        width: 13px;
+        height: 13px;
+        stroke-width: 1.8;
+      }
+      .copy-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+        padding: 0 8px;
+        height: 28px;
+        border-radius: 6px;
+        border: 1px solid var(--border-strong);
+        background: var(--bg);
+        font-family: inherit;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-muted);
+        cursor: pointer;
+      }
+      .copy-btn:hover {
+        border-color: var(--border-hover);
+        color: var(--text-secondary);
+      }
+      .copy-btn svg {
+        width: 13px;
+        height: 13px;
+        stroke-width: 1.8;
+      }
+      .tree {
+        flex: 1;
+        overflow-y: auto;
+        overflow-x: hidden;
+        padding: 8px 0;
+      }
+      .issues {
+        margin: 4px 12px 8px;
+        padding: 10px 14px;
+        background: var(--error-bg);
+        border-radius: 8px;
+        border: 1px solid color-mix(in srgb, var(--error) 15%, transparent);
+      }
+      .issues__header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 8px;
+      }
+      .issues__icon {
+        width: 14px;
+        height: 14px;
+        color: var(--error-strong);
+        stroke-width: 2;
+      }
+      .issues__count {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--error-strong);
+      }
+      .issues__item {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--error-strong);
+        padding: 2px 0 2px 10px;
+        border-left: 2px solid var(--error);
+        margin-left: 2px;
+        margin-bottom: 6px;
+      }
+      .issues__item:last-child {
+        margin-bottom: 0;
+      }
+      .tree__row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+        padding: 5px 12px;
+        border: none;
+        background: none;
+        cursor: pointer;
+        font-family: inherit;
+        text-align: left;
+        overflow: hidden;
+        box-sizing: border-box;
+      }
+      .tree__row:hover {
+        background: var(--bg-hover);
+      }
+      .tree__row--has-issue {
+        background: color-mix(in srgb, var(--error-bg) 50%, transparent);
+      }
+      .tree__badge {
+        font-family: inherit;
+        font-size: 11px;
+        font-weight: 700;
+        padding: 2px 8px;
+        border-radius: 6px;
+        flex-shrink: 0;
+        line-height: 16px;
+        background: var(--accent-tint);
+        color: var(--accent);
+      }
+      .tree__text {
+        font-size: 12.5px;
+        color: var(--text-secondary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+      }
+      .tree__text--empty {
+        font-style: italic;
+        color: var(--text-disabled);
+      }
+      .tree__issue-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--error);
+        flex-shrink: 0;
+        margin-left: auto;
+      }
+
+      /* ===================== Links + Assets (shared) ===================== */
+      .links-tab,
+      .assets-tab {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+      .toolbar {
+        display: flex;
+        flex-direction: column;
+        border-bottom: 1px solid var(--border);
+        flex-shrink: 0;
+      }
+      .toolbar__row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        padding: 10px 20px;
+      }
+      .toolbar__filters {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        flex-wrap: wrap;
+        min-width: 0;
+      }
+      .toolbar__actions {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .dropdown {
+        position: relative;
+      }
+      .dropdown__trigger {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        height: 28px;
+        padding: 0 10px;
+        border-radius: 6px;
+        border: 1px solid var(--border-strong);
+        background: var(--bg);
+        font-family: inherit;
+        font-size: 12.5px;
+        font-weight: 600;
+        color: var(--text-muted);
+        cursor: pointer;
+        box-sizing: border-box;
+      }
+      .dropdown__trigger:hover {
+        border-color: var(--border-hover);
+        color: var(--text-secondary);
+      }
+      .dropdown__trigger--active {
+        border-color: var(--accent);
+      }
+      .dropdown__count {
+        color: var(--text-muted);
+        font-weight: 500;
+      }
+      .dropdown__chevron {
+        width: 12px;
+        height: 12px;
+        stroke-width: 2;
+        color: var(--text-muted);
+      }
+      .dropdown__menu {
+        position: absolute;
+        top: calc(100% + 4px);
+        left: 0;
+        background: var(--bg);
+        border: 1px solid var(--border-strong);
+        border-radius: 8px;
+        box-shadow: var(--shadow-pop);
+        z-index: 10;
+        min-width: 160px;
+        padding: 4px;
+      }
+      .dropdown__item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        padding: 6px 10px;
+        border: none;
+        background: none;
+        font-family: inherit;
+        font-size: 12.5px;
+        font-weight: 500;
+        color: var(--text-secondary);
+        cursor: pointer;
+        border-radius: 5px;
+      }
+      .dropdown__item:hover {
+        background: var(--bg-hover);
+      }
+      .dropdown__item--active {
+        color: var(--text);
+        font-weight: 600;
+      }
+      .dropdown__item-count {
+        font-size: 11.5px;
+        font-weight: 500;
+        color: var(--text-muted);
+      }
+      .export {
+        position: relative;
+      }
+      .export__trigger {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 0 8px;
+        height: 28px;
+        border-radius: 6px;
+        border: 1px solid var(--border-strong);
+        background: var(--bg);
+        font-family: inherit;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-muted);
+        cursor: pointer;
+        box-sizing: border-box;
+      }
+      .export__trigger:hover {
+        border-color: var(--border-hover);
+        color: var(--text-secondary);
+      }
+      .export__icon {
+        width: 13px;
+        height: 13px;
+        stroke-width: 1.8;
+      }
+      .export__chevron {
+        width: 10px;
+        height: 10px;
+        stroke-width: 2;
+        opacity: 0.6;
+      }
+      .toolbar-btn {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 0 8px;
+        height: 28px;
+        border-radius: 6px;
+        border: 1px solid var(--border-strong);
+        background: var(--bg);
+        font-family: inherit;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-muted);
+        cursor: pointer;
+        box-sizing: border-box;
+      }
+      .toolbar-btn:hover {
+        border-color: var(--border-hover);
+        color: var(--text-secondary);
+      }
+      .toolbar-btn--active {
+        background: var(--btn-bg);
+        color: var(--btn-text);
+        border-color: var(--btn-bg);
+      }
+      .toolbar-btn svg {
+        width: 13px;
+        height: 13px;
+        stroke-width: 1.8;
+        flex-shrink: 0;
+      }
+      .reset-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        border-radius: 6px;
+        border: 1px solid var(--border-strong);
+        background: var(--bg);
+        color: var(--text-muted);
+        cursor: pointer;
+        flex-shrink: 0;
+        box-sizing: border-box;
+      }
+      .reset-btn:hover {
+        border-color: var(--border-hover);
+        color: var(--text-secondary);
+      }
+      .reset-btn svg {
+        width: 14px;
+        height: 14px;
+        stroke-width: 1.8;
+      }
+      .table-wrap {
+        flex: 1;
+        overflow-y: auto;
+        overflow-x: hidden;
+        padding: 0 20px;
+      }
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+        table-layout: fixed;
+      }
+      .th {
+        text-align: left;
+        font-size: 10.5px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--text-label);
+        padding: 8px 8px 8px 0;
+        border-bottom: 1px solid var(--border);
+        position: sticky;
+        top: 0;
+        background: var(--bg-canvas);
+        z-index: 1;
+      }
+      .th--num {
+        width: 30px;
+        padding-right: 0;
+      }
+      .th--follow,
+      .th--type {
+        width: 76px;
+      }
+      .th--size {
+        width: 64px;
+      }
+      .th--time {
+        width: 58px;
+      }
+      .th--kind {
+        width: 60px;
+      }
+      .th--load {
+        width: 64px;
+      }
+      .th__count {
+        font-weight: 500;
+        color: var(--text-muted);
+        letter-spacing: 0;
+        text-transform: none;
+      }
+      .th-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 2px;
+        padding: 0;
+        border: none;
+        background: none;
+        font: inherit;
+        color: inherit;
+        text-transform: inherit;
+        letter-spacing: inherit;
+        cursor: pointer;
+      }
+      .th-btn:hover,
+      .th-btn--active {
+        color: var(--text-secondary);
+      }
+      .sort-arrow {
+        width: 11px;
+        height: 11px;
+        stroke-width: 2.5;
+        flex-shrink: 0;
+      }
+      .sort-arrow--idle {
+        opacity: 0.4;
+      }
+      .row {
+        cursor: pointer;
+        transition: background 0.1s;
+      }
+      .row:hover {
+        background: var(--bg-hover);
+      }
+      .td {
+        padding: 9px 8px 9px 0;
+        color: var(--text-secondary);
+        border-bottom: 1px solid var(--border-muted);
+        vertical-align: middle;
+      }
+      .td--num {
+        color: var(--text-muted);
+        font-size: 12px;
+        padding-right: 0;
+      }
+      .td--url,
+      .td--src {
+        overflow: hidden;
+      }
+      .url-row,
+      .src-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+      }
+      .url,
+      .src {
+        color: var(--accent);
+        text-decoration: none;
+        font-family: 'SF Mono', ui-monospace, monospace;
+        font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+      }
+      .url:hover,
+      .src:hover {
+        text-decoration: underline;
+      }
+      .src--inline {
+        color: var(--text-muted);
+        font-style: italic;
+      }
+      .dup-badge {
+        flex-shrink: 0;
+        font-size: 10px;
+        font-weight: 600;
+        padding: 0 5px;
+        border-radius: 8px;
+        line-height: 16px;
+        background: var(--warning-bg);
+        color: var(--warning);
+      }
+      .anchor-text {
+        display: block;
+        font-size: 11.5px;
+        color: var(--text-secondary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        margin-top: 1px;
+      }
+      .anchor-text--empty {
+        color: var(--error);
+        font-style: italic;
+      }
+      .anchor-text--image {
+        color: var(--text-muted);
+        font-style: italic;
+      }
+      .td--size,
+      .td--time {
+        font-size: 12px;
+        color: var(--text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      .time-cached {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--success-strong);
+      }
+      .muted {
+        color: var(--text-muted);
+      }
+      .load-tag {
+        font-size: 12px;
+        color: var(--text-secondary);
+      }
+      .load-tag--na {
+        color: var(--text-muted);
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        flex-shrink: 0;
+        font-size: 10px;
+        font-weight: 600;
+        padding: 1px 7px;
+        border-radius: 20px;
+        white-space: nowrap;
+      }
+      .pill--green {
+        background: var(--success-bg);
+        color: var(--success-strong);
+      }
+      .pill--red {
+        background: var(--error-bg);
+        color: var(--error-strong);
+      }
+      .pill--amber {
+        background: var(--warning-bg);
+        color: var(--warning);
+      }
+
+      /* ============================ Settings ============================ */
+      .password-section {
+        padding: 14px 0;
+        border-top: 1px solid var(--border);
+      }
+      .password-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 12px;
+      }
+      .field-label {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-muted);
+      }
+      .toggle-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .checkbox {
+        width: 16px;
+        height: 16px;
+        accent-color: var(--text);
+        border-radius: 4px;
+      }
+      .toggle-text {
+        font-size: 12px;
+        color: var(--text-secondary);
+      }
+      .input-row {
+        position: relative;
+        display: flex;
+        gap: 8px;
+      }
+      .input-wrapper {
+        position: relative;
+        flex: 1;
+      }
+      .password-input {
+        width: 100%;
+        padding: 8px 36px 8px 12px;
+        font-size: 13px;
+        font-family: inherit;
+        border: 1px solid var(--border-strong);
+        border-radius: 8px;
+        outline: none;
+        box-sizing: border-box;
+        color: var(--text);
+        background: var(--bg);
+      }
+      .password-input:focus {
+        border-color: var(--border-hover);
+      }
+      .eye-btn {
+        position: absolute;
+        right: 8px;
+        top: 50%;
+        transform: translateY(-50%);
+        padding: 6px;
+        border-radius: 4px;
+        border: none;
+        background: none;
+        cursor: pointer;
+        color: var(--text-muted);
+      }
+      .eye-icon {
+        width: 16px;
+        height: 16px;
+        fill: currentColor;
+      }
+      .save-btn {
+        width: 110px;
+        padding: 8px 0;
+        border-radius: 8px;
+        font-weight: 600;
+        font-size: 13px;
+        font-family: inherit;
+        border: none;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        flex-shrink: 0;
+        background: var(--btn-bg);
+        color: var(--btn-text);
+      }
+      .save-btn:hover {
+        background: var(--btn-bg-hover);
+      }
+      .save-icon {
+        width: 16px;
+        height: 16px;
+      }
+
+      /* ===================== States (empty / loading / not-Shopify) ===================== */
+      .empty-state {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        gap: 8px;
+        color: var(--text-muted);
+      }
+      .empty-state__icon {
+        width: 28px;
+        height: 28px;
+        opacity: 0.3;
+        stroke-width: 1.7;
+      }
+      .empty-state p {
+        font-size: 13px;
+        margin: 0;
+      }
+      .loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        height: 100%;
+        color: var(--text-link-muted);
+        font-size: 14px;
+      }
+      .loading__spinner {
+        width: 20px;
+        height: 20px;
+        border: 2px solid var(--border-strong);
+        border-top-color: var(--accent);
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .not-shopify {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        gap: 8px;
+        text-align: center;
+      }
+      .not-shopify__icon {
+        width: 28px;
+        height: 28px;
+        color: var(--text-disabled);
+        stroke-width: 1.7;
+      }
+      .not-shopify h3 {
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--text-secondary);
+        margin: 0;
+      }
+      .not-shopify p {
+        font-size: 13px;
+        color: var(--text-muted);
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="popup">
+      <!-- Brand bar -->
+      <div class="brand">
+        <div style="display: flex; align-items: center; gap: 7px"><span class="brand__name">Alfred</span></div>
+        <div class="prompt--compact">
+          <span class="prompt__label">Enjoying Alfred?</span>
+          <div class="prompt__stars">
+            <button class="prompt__star">
+              <svg class="prompt__svg" viewBox="0 0 24 24" fill="#E0E0E0">
+                <path
+                  d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+              </svg>
+            </button>
+            <button class="prompt__star">
+              <svg class="prompt__svg" viewBox="0 0 24 24" fill="#E0E0E0">
+                <path
+                  d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+              </svg>
+            </button>
+            <button class="prompt__star">
+              <svg class="prompt__svg" viewBox="0 0 24 24" fill="#E0E0E0">
+                <path
+                  d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+              </svg>
+            </button>
+            <button class="prompt__star">
+              <svg class="prompt__svg" viewBox="0 0 24 24" fill="#E0E0E0">
+                <path
+                  d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+              </svg>
+            </button>
+            <button class="prompt__star">
+              <svg class="prompt__svg" viewBox="0 0 24 24" fill="#E0E0E0">
+                <path
+                  d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="layout">
+        <!-- Sidebar -->
+        <nav class="sidebar" aria-label="Alfred navigation">
+          <div class="sidebar__label">
+            <svg width="70" height="20" viewBox="0 0 100 28.6" aria-hidden="true">
+              <path
+                d="M11.3,1c0.2,0,0.3,0.1,0.5,0.2C10.6,1.7,9.4,3,8.8,5.8L6.6,6.4C7.3,4.4,8.7,1,11.3,1z M12.4,2c0.2,0.6,0.4,1.3,0.4,2.4c0,0.1,0,0.1,0,0.2L9.9,5.4C10.5,3.3,11.5,2.4,12.4,2z M15,3.8l-1.3,0.4c0-0.1,0-0.2,0-0.3c0-0.9-0.1-1.6-0.3-2.2C14.1,1.9,14.7,2.8,15,3.8z M21.5,5.4c0-0.1-0.1-0.2-0.2-0.2C21.1,5.2,19,5,19,5s-1.5-1.5-1.7-1.6c-0.2-0.2-0.5-0.1-0.6-0.1c0,0-0.3,0.1-0.8,0.3c-0.5-1.4-1.4-2.7-2.9-2.7c0,0-0.1,0-0.1,0c-0.4-0.6-1-0.8-1.5-0.8C7.8,0,6.1,4.5,5.5,6.8C4.7,7,3.9,7.3,3,7.6c-0.8,0.2-0.8,0.3-0.9,1C2,9.1,0,24.9,0,24.9l15.9,3l8.6-1.9C24.5,26,21.5,5.6,21.5,5.4z"
+                fill="#95BF47" />
+              <path
+                d="M21.2,5.2C21.1,5.2,19,5,19,5s-1.5-1.5-1.7-1.6c-0.1-0.1-0.1-0.1-0.2-0.1l-1.2,24.6l8.6-1.9c0,0-3-20.4-3-20.6C21.5,5.3,21.3,5.2,21.2,5.2"
+                fill="#5A863E" />
+              <path
+                d="M13,10l-1.1,3.2c0,0-0.9-0.5-2.1-0.5c-1.7,0-1.8,1-1.8,1.3c0,1.4,3.8,2,3.8,5.4c0,2.7-1.7,4.4-4,4.4c-2.7,0-4.1-1.7-4.1-1.7l0.7-2.4c0,0,1.4,1.2,2.6,1.2c0.8,0,1.1-0.6,1.1-1.1c0-1.9-3.1-2-3.1-5.1c0-2.6,1.9-5.1,5.6-5.1C12.3,9.5,13,10,13,10"
+                fill="#FFF" />
+              <path
+                d="M34.6,15.9c-0.9-0.5-1.3-0.9-1.3-1.4c0-0.7,0.6-1.1,1.6-1.1c1.1,0,2.1,0.5,2.1,0.5l0.8-2.4c0,0-0.7-0.6-2.8-0.6c-3,0-5,1.7-5,4.1c0,1.4,1,2.4,2.2,3.1c1,0.6,1.4,1,1.4,1.6c0,0.6-0.5,1.2-1.5,1.2c-1.4,0-2.8-0.7-2.8-0.7l-0.8,2.4c0,0,1.2,0.8,3.3,0.8c3,0,5.2-1.5,5.2-4.2C37,17.7,35.9,16.6,34.6,15.9 M46.7,10.8c-1.5,0-2.7,0.7-3.6,1.8l0,0l1.3-6.8H41l-3.3,17.3h3.4l1.1-5.9c0.4-2.2,1.6-3.6,2.7-3.6c0.8,0,1.1,0.5,1.1,1.3c0,0.5,0,1-0.1,1.5l-1.3,6.8h3.4l1.3-7c0.1-0.7,0.2-1.6,0.2-2.2C49.5,12,48.5,10.8,46.7,10.8 M55.4,20.7c-1.2,0-1.6-1-1.6-2.2c0-1.9,1-5.1,2.8-5.1c1.2,0,1.6,1,1.6,2C58.2,17.6,57.2,20.7,55.4,20.7z M57.1,10.8c-4.1,0-6.8,3.7-6.8,7.8c0,2.6,1.6,4.7,4.7,4.7c4,0,6.7-3.6,6.7-7.8C61.7,13.1,60.3,10.8,57.1,10.8z M67.1,20.8c-0.9,0-1.4-0.5-1.4-0.5l0.6-3.2c0.4-2.1,1.5-3.5,2.7-3.5c1,0,1.4,1,1.4,1.9C70.3,17.7,69,20.8,67.1,20.8z M70.4,10.8c-2.3,0-3.6,2-3.6,2h0l0.2-1.8h-3c-0.1,1.2-0.4,3.1-0.7,4.5l-2.4,12.4h3.4l0.9-5h0.1c0,0,0.7,0.4,2,0.4c4,0,6.6-4.1,6.6-8.2C73.9,12.9,72.9,10.8,70.4,10.8z M78.7,6c-1.1,0-1.9,0.9-1.9,2c0,1,0.6,1.7,1.6,1.7h0c1.1,0,2-0.7,2-2C80.4,6.7,79.7,6,78.7,6 M74,23.1h3.4l2.3-12h-3.4L74,23.1z M88.3,11.1h-2.4l0.1-0.6c0.2-1.2,0.9-2.2,2-2.2c0.6,0,1.1,0.2,1.1,0.2l0.7-2.7c0,0-0.6-0.3-1.8-0.3c-1.2,0-2.4,0.3-3.3,1.1c-1.2,1-1.7,2.4-2,3.8l-0.1,0.6H81l-0.5,2.6h1.6l-1.8,9.5h3.4l1.8-9.5h2.3L88.3,11.1z M96.4,11.1c0,0-2.1,5.3-3.1,8.2h0c-0.1-0.9-0.8-8.2-0.8-8.2h-3.6l2,11c0,0.2,0,0.4-0.1,0.6c-0.4,0.8-1.1,1.5-1.8,2c-0.6,0.5-1.4,0.8-1.9,1l0.9,2.9c0.7-0.1,2.1-0.7,3.3-1.8c1.5-1.4,3-3.7,4.4-6.7l4.1-8.9L96.4,11.1z"
+                fill="#1A1919" />
+            </svg>
+          </div>
+          <div>
+            <button class="tab active" data-tab="theme" onclick="sw('theme')">
+              <svg viewBox="0 0 16 16" fill="currentColor" stroke="none">
+                <path
+                  fill-rule="evenodd"
+                  d="M5.25 1.5a3.75 3.75 0 0 0-3.75 3.75v5.5a3.75 3.75 0 0 0 3.75 3.75h5.5a3.75 3.75 0 0 0 3.75-3.75v-5.5a3.75 3.75 0 0 0-3.75-3.75zm-2.25 3.75a2.25 2.25 0 0 1 2.25-2.25h3.25v3h-5.5zm7-2.25h.75a2.25 2.25 0 0 1 2.25 2.25v3.75h-3zm0 7.5v2.5h.75a2.25 2.25 0 0 0 2.25-2.25v-.25zm-1.5-3v5.5h-3.25a2.25 2.25 0 0 1-2.25-2.25v-3.25z" /></svg
+              >Theme
+            </button>
+          </div>
+          <div class="sidebar__divider"></div>
+          <div class="sidebar__label">SEO</div>
+          <div>
+            <button class="tab" data-tab="headings" onclick="sw('headings')">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                <path d="M4 6h16M4 12h8m-8 6h16" /></svg
+              >Headings<span class="tab__badge tab__badge--red">2</span>
+            </button>
+            <button class="tab" data-tab="links" onclick="sw('links')">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" />
+                <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" /></svg
+              >Links
+            </button>
+            <button class="tab" data-tab="assets" onclick="sw('assets')">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                <polyline points="16 18 22 12 16 6" />
+                <polyline points="8 6 2 12 8 18" /></svg
+              >Assets
+            </button>
+          </div>
+          <div class="sidebar__bottom">
+            <button class="tab" data-tab="settings" onclick="sw('settings')">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                <circle cx="12" cy="12" r="3" />
+                <path
+                  d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" /></svg
+              >Settings
+            </button>
+            <a href="#" class="sidebar__suggest">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg
+              >Suggest a feature
+            </a>
+          </div>
+        </nav>
+
+        <!-- Content -->
+        <div class="content" role="main">
+          <!-- THEME -->
+          <div class="panel active" id="panel-theme">
+            <div class="hero">
+              <div class="hero__identity">
+                <div class="hero__meta">
+                  <h1 class="hero__name">Dawn</h1>
+                  <div class="hero__byline">
+                    <span>by <a class="hero__developer-link" href="#">Shopify</a></span>
+                    <span class="hero__byline-dot"></span><span>Free</span> <span class="hero__byline-dot"></span
+                    ><span>v15.0.0</span>
+                  </div>
+                  <div class="hero__store-url">
+                    <span class="hero__store-domain">theme-dawn-demo.myshopify.com</span>
+                    <svg
+                      class="copy-trigger"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.7"
+                      stroke-linecap="round">
+                      <rect x="9" y="9" width="13" height="13" rx="2" />
+                      <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                    </svg>
+                  </div>
+                </div>
+                <div class="hero__actions">
+                  <a class="btn btn--ghost" href="#"
+                    ><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                      <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
+                      <path d="M3 6h18" /></svg
+                    >Theme Store</a
+                  >
+                  <a class="btn btn--primary" href="#"
+                    ><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                      <circle cx="12" cy="12" r="3" /></svg
+                    >Demo</a
+                  >
+                </div>
+              </div>
+            </div>
+            <div class="stats">
+              <div class="stats__cell">
+                <div class="stats__label">Theme ID</div>
+                <div class="stats__value">
+                  <code class="stats__code">129690763353</code
+                  ><svg
+                    class="copy-trigger"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.7"
+                    stroke-linecap="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" />
+                    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                  </svg>
+                </div>
+              </div>
+              <div class="stats__cell">
+                <div class="stats__label">Version</div>
+                <div class="stats__value">
+                  15.0.0
+                  <span class="stats__update"
+                    ><svg
+                      viewBox="0 0 12 12"
+                      width="10"
+                      height="10"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round">
+                      <path d="M6 10V2M3 5l3-3 3 3" /></svg
+                    >15.4.1</span
+                  >
+                </div>
+              </div>
+              <div class="stats__cell">
+                <div class="stats__label">Status</div>
+                <div class="stats__value">
+                  <span class="stats__status-dot" style="background: var(--success)"></span>Published
+                </div>
+              </div>
+            </div>
+            <div class="sections">
+              <div class="section" style="margin-bottom: 20px">
+                <div class="internal-name">
+                  <span class="internal-name__label">Internal Name</span>
+                  <span class="internal-name__value">Dawn-15-0-0</span>
+                  <svg
+                    class="copy-trigger"
+                    style="margin-left: auto"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.7"
+                    stroke-linecap="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" />
+                    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                  </svg>
+                </div>
+              </div>
+              <div class="section">
+                <div class="section__title">Preview URL</div>
+                <div class="preview">
+                  <div class="preview__url">
+                    <svg
+                      class="preview__icon"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.7"
+                      stroke-linecap="round">
+                      <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" />
+                      <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" />
+                    </svg>
+                    <input
+                      class="preview__input"
+                      value="https://theme-dawn-demo.myshopify.com/?preview_theme_id=129690763353"
+                      readonly />
+                    <button class="btn btn--ghost preview__copy">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                        <rect x="9" y="9" width="13" height="13" rx="2" />
+                        <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" /></svg
+                      >Copy
+                    </button>
+                  </div>
+                  <div class="preview__footer">
+                    <div class="toggle">
+                      <span class="toggle__text">Hide preview bar</span>
+                      <div class="toggle__track"><div class="toggle__knob"></div></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- HEADINGS -->
+          <div class="panel panel--flex" id="panel-headings">
+            <div class="headings">
+              <div class="statusbar">
+                <div class="counts">
+                  <span class="counts__item"
+                    ><span class="counts__label">H1</span><span class="counts__value">1</span></span
+                  >
+                  <span class="counts__item"
+                    ><span class="counts__label">H2</span><span class="counts__value">10</span></span
+                  >
+                  <span class="counts__item"
+                    ><span class="counts__label">H3</span><span class="counts__value">22</span></span
+                  >
+                  <span class="counts__item counts__item--zero"
+                    ><span class="counts__label">H4</span><span class="counts__value">0</span></span
+                  >
+                  <span class="counts__item counts__item--zero"
+                    ><span class="counts__label">H5</span><span class="counts__value">0</span></span
+                  >
+                  <span class="counts__item counts__item--zero"
+                    ><span class="counts__label">H6</span><span class="counts__value">0</span></span
+                  >
+                </div>
+                <div class="statusbar__actions">
+                  <button class="filter">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                      <path
+                        d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24" />
+                      <line x1="1" y1="1" x2="23" y2="23" /></svg
+                    >3 hidden
+                  </button>
+                  <button class="copy-btn">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                      <rect x="9" y="9" width="13" height="13" rx="2" />
+                      <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" /></svg
+                    >Copy
+                  </button>
+                </div>
+              </div>
+              <div class="tree">
+                <div class="issues">
+                  <div class="issues__header">
+                    <svg
+                      class="issues__icon"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round">
+                      <circle cx="12" cy="12" r="10" />
+                      <path d="M12 8v4m0 4h.01" /></svg
+                    ><span class="issues__count">2 issues</span>
+                  </div>
+                  <div class="issues__item">Empty H1 tag</div>
+                  <div class="issues__item">Skipped from H2 to H4</div>
+                </div>
+                <div class="tree__row" style="padding-left: 12px">
+                  <span class="tree__badge tree__badge--h1">H1</span
+                  ><span class="tree__text tree__text--empty">(empty)</span><span class="tree__issue-dot"></span>
+                </div>
+                <div class="tree__row" style="padding-left: 28px">
+                  <span class="tree__badge tree__badge--h2">H2</span
+                  ><span class="tree__text">Industrial design meets fashion</span>
+                </div>
+                <div class="tree__row" style="padding-left: 44px">
+                  <span class="tree__badge tree__badge--h3">H3</span
+                  ><span class="tree__text">Small Convertible Flex Bag</span>
+                </div>
+                <div class="tree__row" style="padding-left: 44px">
+                  <span class="tree__badge tree__badge--h3">H3</span><span class="tree__text">Studio Bag</span>
+                </div>
+                <div class="tree__row" style="padding-left: 28px">
+                  <span class="tree__badge tree__badge--h2">H2</span
+                  ><span class="tree__text">Obsessive attention, intelligent effort</span>
+                </div>
+                <div class="tree__row" style="padding-left: 60px">
+                  <span class="tree__badge tree__badge--h4">H4</span><span class="tree__text">Back in stock</span
+                  ><span class="tree__issue-dot"></span>
+                </div>
+                <div class="tree__row" style="padding-left: 28px">
+                  <span class="tree__badge tree__badge--h2">H2</span
+                  ><span class="tree__text">Subscribe to our emails</span>
+                </div>
+                <div class="tree__row" style="padding-left: 60px">
+                  <span class="tree__badge tree__badge--h5">H5</span
+                  ><span class="tree__text">Shipping &amp; returns</span>
+                </div>
+                <div class="tree__row" style="padding-left: 76px">
+                  <span class="tree__badge tree__badge--h6">H6</span><span class="tree__text">Size guide</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- LINKS -->
+          <div class="panel panel--flex" id="panel-links">
+            <div class="links-tab">
+              <div class="toolbar">
+                <div class="toolbar__row">
+                  <div class="toolbar__filters">
+                    <div class="dropdown">
+                      <button class="dropdown__trigger dropdown__trigger--active">
+                        External <span class="dropdown__count">11</span
+                        ><svg
+                          class="dropdown__chevron"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round">
+                          <path d="M6 9l6 6 6-6" />
+                        </svg>
+                      </button>
+                      <div class="dropdown__menu">
+                        <button class="dropdown__item">All<span class="dropdown__item-count">108</span></button>
+                        <button class="dropdown__item">Internal<span class="dropdown__item-count">97</span></button>
+                        <button class="dropdown__item dropdown__item--active">
+                          External<span class="dropdown__item-count">11</span>
+                        </button>
+                      </div>
+                    </div>
+                    <div class="dropdown">
+                      <button class="dropdown__trigger">
+                        Follow<svg
+                          class="dropdown__chevron"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round">
+                          <path d="M6 9l6 6 6-6" />
+                        </svg>
+                      </button>
+                    </div>
+                    <div class="dropdown">
+                      <button class="dropdown__trigger">
+                        Anchor<svg
+                          class="dropdown__chevron"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round">
+                          <path d="M6 9l6 6 6-6" />
+                        </svg>
+                      </button>
+                    </div>
+                    <button class="reset-btn">
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round">
+                        <polyline points="1 4 1 10 7 10" />
+                        <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+                      </svg>
+                    </button>
+                  </div>
+                  <div class="toolbar__actions">
+                    <button class="toolbar-btn">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                        <circle cx="12" cy="12" r="3" /></svg
+                      >Highlight
+                    </button>
+                    <button class="toolbar-btn">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round">
+                        <circle cx="11" cy="11" r="8" />
+                        <path d="M21 21l-4.35-4.35" />
+                      </svg>
+                    </button>
+                    <button class="export__trigger">
+                      <svg
+                        class="export__icon"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round">
+                        <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                        <polyline points="7 10 12 15 17 10" />
+                        <line x1="12" y1="15" x2="12" y2="3" /></svg
+                      >Export<svg
+                        class="export__chevron"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round">
+                        <path d="M6 9l6 6 6-6" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="table-wrap">
+                <table class="table">
+                  <thead>
+                    <tr>
+                      <th class="th th--num">
+                        <button class="th-btn th-btn--active">
+                          #<svg
+                            class="sort-arrow"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round">
+                            <path d="M18 15l-6-6-6 6" />
+                          </svg>
+                        </button>
+                      </th>
+                      <th class="th th--url">
+                        <button class="th-btn">Target URL</button> <span class="th__count">(11/108)</span>
+                      </th>
+                      <th class="th th--follow"><button class="th-btn">Dofollow</button></th>
+                      <th class="th th--type"><button class="th-btn">Type</button></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr class="row">
+                      <td class="td td--num">1</td>
+                      <td class="td td--url">
+                        <div class="url-row"><a class="url" href="#">facebook.com/shopify</a></div>
+                        <span class="anchor-text anchor-text--image">[image]</span>
+                      </td>
+                      <td class="td td--follow"><span class="pill pill--green">Yes</span></td>
+                      <td class="td td--type">External</td>
+                    </tr>
+                    <tr class="row">
+                      <td class="td td--num">2</td>
+                      <td class="td td--url">
+                        <div class="url-row"><a class="url" href="#">twitter.com/shopify</a></div>
+                        <span class="anchor-text">Follow us on X</span>
+                      </td>
+                      <td class="td td--follow"><span class="pill pill--green">Yes</span></td>
+                      <td class="td td--type">External</td>
+                    </tr>
+                    <tr class="row">
+                      <td class="td td--num">3</td>
+                      <td class="td td--url">
+                        <div class="url-row">
+                          <a class="url" href="#">instagram.com/shopify</a><span class="dup-badge">&times;2</span>
+                        </div>
+                        <span class="anchor-text">Instagram</span>
+                      </td>
+                      <td class="td td--follow"><span class="pill pill--green">Yes</span></td>
+                      <td class="td td--type">External</td>
+                    </tr>
+                    <tr class="row">
+                      <td class="td td--num">4</td>
+                      <td class="td td--url">
+                        <div class="url-row"><a class="url" href="#">shopify.com/?utm_campaign=poweredby</a></div>
+                        <span class="anchor-text anchor-text--empty">(no anchor text)</span>
+                      </td>
+                      <td class="td td--follow"><span class="pill pill--red">No</span></td>
+                      <td class="td td--type">External</td>
+                    </tr>
+                    <tr class="row">
+                      <td class="td td--num">5</td>
+                      <td class="td td--url">
+                        <div class="url-row"><a class="url" href="#">youtube.com/shopify</a></div>
+                        <span class="anchor-text">YouTube channel</span>
+                      </td>
+                      <td class="td td--follow"><span class="pill pill--red">No</span></td>
+                      <td class="td td--type">External</td>
+                    </tr>
+                    <tr class="row">
+                      <td class="td td--num">6</td>
+                      <td class="td td--url">
+                        <div class="url-row"><a class="url" href="#">linkedin.com/company/shopify</a></div>
+                        <span class="anchor-text">LinkedIn</span>
+                      </td>
+                      <td class="td td--follow"><span class="pill pill--green">Yes</span></td>
+                      <td class="td td--type">External</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <!-- ASSETS -->
+          <div class="panel panel--flex" id="panel-assets">
+            <div class="assets-tab">
+              <div class="toolbar">
+                <div class="toolbar__row">
+                  <div class="toolbar__filters">
+                    <div class="dropdown">
+                      <button class="dropdown__trigger">
+                        Kind<svg
+                          class="dropdown__chevron"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round">
+                          <path d="M6 9l6 6 6-6" />
+                        </svg>
+                      </button>
+                    </div>
+                    <div class="dropdown">
+                      <button class="dropdown__trigger dropdown__trigger--active">
+                        Render-blocking <span class="dropdown__count">3</span
+                        ><svg
+                          class="dropdown__chevron"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round">
+                          <path d="M6 9l6 6 6-6" />
+                        </svg>
+                      </button>
+                    </div>
+                    <button class="reset-btn">
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round">
+                        <polyline points="1 4 1 10 7 10" />
+                        <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+                      </svg>
+                    </button>
+                  </div>
+                  <div class="toolbar__actions">
+                    <button class="export__trigger">
+                      <svg
+                        class="export__icon"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round">
+                        <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                        <polyline points="7 10 12 15 17 10" />
+                        <line x1="12" y1="15" x2="12" y2="3" /></svg
+                      >Export<svg
+                        class="export__chevron"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round">
+                        <path d="M6 9l6 6 6-6" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="table-wrap">
+                <table class="table">
+                  <thead>
+                    <tr>
+                      <th class="th th--num">#</th>
+                      <th class="th th--src">
+                        <button class="th-btn th-btn--active">
+                          Source<svg
+                            class="sort-arrow"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round">
+                            <path d="M18 15l-6-6-6 6" />
+                          </svg>
+                        </button>
+                        <span class="th__count">(24)</span>
+                      </th>
+                      <th class="th th--size"><button class="th-btn">Size</button></th>
+                      <th class="th th--time"><button class="th-btn">Time</button></th>
+                      <th class="th th--kind">Kind</th>
+                      <th class="th th--load">Load</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr class="row">
+                      <td class="td td--num">1</td>
+                      <td class="td td--src">
+                        <div class="src-row">
+                          <a class="src" href="#">cdn.shopify.com/.../theme.min.js</a
+                          ><span class="pill pill--amber">render-blocking</span>
+                        </div>
+                      </td>
+                      <td class="td td--size">128 KB</td>
+                      <td class="td td--time">240 ms</td>
+                      <td class="td td--kind">Script</td>
+                      <td class="td td--load"><span class="load-tag">defer</span></td>
+                    </tr>
+                    <tr class="row">
+                      <td class="td td--src">
+                        <div class="src-row"><a class="src" href="#">cdn.shopify.com/.../base.css</a></div>
+                      </td>
+                      <td class="td td--num">2</td>
+                      <td class="td td--size">64 KB</td>
+                      <td class="td td--time"><span class="time-cached">cached</span></td>
+                      <td class="td td--kind">Style</td>
+                      <td class="td td--load"><span class="load-tag load-tag--na">-</span></td>
+                    </tr>
+                    <tr class="row">
+                      <td class="td td--num">3</td>
+                      <td class="td td--src">
+                        <div class="src-row">
+                          <a class="src" href="#">klaviyo.com/onsite/js/klaviyo.js</a
+                          ><span class="pill pill--red" title="404">404</span>
+                        </div>
+                      </td>
+                      <td class="td td--size"><span class="muted">-</span></td>
+                      <td class="td td--time">18 ms</td>
+                      <td class="td td--kind">Script</td>
+                      <td class="td td--load"><span class="load-tag">async</span></td>
+                    </tr>
+                    <tr class="row">
+                      <td class="td td--num">4</td>
+                      <td class="td td--src">
+                        <div class="src-row"><span class="src src--inline">inline</span></div>
+                      </td>
+                      <td class="td td--size">2.1 KB</td>
+                      <td class="td td--time"><span class="muted">-</span></td>
+                      <td class="td td--kind">Script</td>
+                      <td class="td td--load"><span class="load-tag">inline</span></td>
+                    </tr>
+                    <tr class="row">
+                      <td class="td td--num">5</td>
+                      <td class="td td--src">
+                        <div class="src-row">
+                          <a class="src" href="#">cdn.shopify.com/.../vendor.js</a
+                          ><span class="dup-badge">&times;3</span>
+                        </div>
+                      </td>
+                      <td class="td td--size">312 KB</td>
+                      <td class="td td--time">410 ms</td>
+                      <td class="td td--kind">Script</td>
+                      <td class="td td--load"><span class="load-tag">sync</span></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <!-- STATES (empty / loading / not-Shopify) -->
+          <div class="panel panel--flex" id="panel-empty">
+            <div class="empty-state">
+              <svg
+                class="empty-state__icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round">
+                <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" />
+                <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" />
+              </svg>
+              <p>No links found on this page</p>
+            </div>
+          </div>
+          <div class="panel panel--flex" id="panel-loading">
+            <div class="loading">
+              <div class="loading__spinner"></div>
+              <span>Analyzing page...</span>
+            </div>
+          </div>
+          <div class="panel panel--flex" id="panel-notshopify">
+            <div class="not-shopify">
+              <svg
+                class="not-shopify__icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round">
+                <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4z" />
+                <path d="M3 6h18" />
+              </svg>
+              <h3>Not a Shopify store</h3>
+              <p>Navigate to a Shopify store to see theme details</p>
+            </div>
+          </div>
+
+          <!-- SETTINGS -->
+          <div class="panel" id="panel-settings">
+            <div class="content__pad">
+              <div class="password-section">
+                <div class="password-header">
+                  <label class="field-label">Storefront password:</label>
+                  <label class="toggle-row"
+                    ><input type="checkbox" class="checkbox" checked /><span class="toggle-text"
+                      >Auto-fill password?</span
+                    ></label
+                  >
+                </div>
+                <div class="input-row">
+                  <div class="input-wrapper">
+                    <input class="password-input" type="password" value="supersecret" />
+                    <button class="eye-btn">
+                      <svg class="eye-icon" viewBox="0 0 20 20">
+                        <path
+                          fill-rule="evenodd"
+                          d="M13 10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm-1.5 0a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
+                        <path
+                          fill-rule="evenodd"
+                          d="M10 4c-2.476 0-4.348 1.23-5.577 2.532a9.266 9.266 0 0 0-1.4 1.922 5.98 5.98 0 0 0-.37.818c-.082.227-.153.488-.153.728s.071.501.152.728c.088.246.213.524.371.818.317.587.784 1.27 1.4 1.922 1.229 1.302 3.1 2.532 5.577 2.532 2.476 0 4.348-1.23 5.577-2.532a9.265 9.265 0 0 0 1.4-1.922 5.98 5.98 0 0 0 .37-.818c.082-.227.153-.488.153-.728s-.071-.501-.152-.728a5.984 5.984 0 0 0-.371-.818 9.269 9.269 0 0 0-1.4-1.922c-1.229-1.302-3.1-2.532-5.577-2.532Z" />
+                      </svg>
+                    </button>
+                  </div>
+                  <button class="save-btn">
+                    <svg class="save-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" /></svg
+                    ><span>Save</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      function sw(t) {
+        document.querySelectorAll('.tab').forEach((e) => e.classList.toggle('active', e.dataset.tab === t));
+        document.querySelectorAll('.panel').forEach((p) => p.classList.toggle('active', p.id === 'panel-' + t));
+      }
+    </script>
+  </body>
+</html>

--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -205,7 +205,7 @@
 
 <style>
   /* Popup block */
-  .popup { width: 790px; height: 550px; background: var(--bg); display: flex; flex-direction: column; overflow: hidden; }
+  .popup { width: 790px; height: 550px; background: var(--bg-canvas); display: flex; flex-direction: column; overflow: hidden; }
   .popup--compact { width: 350px; height: 200px; }
 
   /* Brand block */
@@ -231,7 +231,7 @@
   /* Tab block */
   .tab { display: flex; align-items: center; gap: 7px; padding: 7px 10px; margin: 1px 6px; border-radius: 7px; font-size: 13.5px; font-weight: 500; color: var(--text-link); cursor: pointer; border: none; background: none; width: calc(100% - 12px); text-align: left; transition: all 0.12s ease; font-family: inherit; }
   .tab:hover { background: var(--bg-hover); color: var(--text-link-hover); }
-  .tab.active { background: var(--bg); color: var(--text); font-weight: 500; text-shadow: 0 0 0.5px var(--text), 0 0 0.5px var(--text); box-shadow: var(--shadow-tab); }
+  .tab.active { background: var(--bg); color: var(--text); font-weight: 600; box-shadow: var(--shadow-tab); }
   /* .tab.disabled { color: var(--text-disabled); cursor: default; }
   .tab.disabled:hover { background: none; color: var(--text-disabled); } */
   .tab :global(svg) { width: 15px; height: 15px; flex-shrink: 0; opacity: 0.5; stroke-width: 1.8; }
@@ -241,7 +241,7 @@
   .tab__badge--green { background: var(--success-bg); color: var(--success-strong); }
 
   /* Content block */
-  .content { flex: 1; overflow-y: auto; overflow-x: hidden; background: var(--bg); scrollbar-gutter: stable; }
+  .content { flex: 1; overflow-y: auto; overflow-x: hidden; background: var(--bg-canvas); scrollbar-gutter: stable; }
   .content::-webkit-scrollbar { width: 3px; }
   .content::-webkit-scrollbar-thumb { background: var(--scrollbar); border-radius: 3px; }
   .content__pad { padding: 24px 28px 28px; }
@@ -249,8 +249,8 @@
   /* Coming-soon block (uncomment when disabled tabs are re-enabled)
   .coming-soon { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; color: var(--text-link-muted); gap: 8px; }
   .coming-soon__icon :global(svg) { width: 32px; height: 32px; opacity: 0.2; stroke-width: 1.5; }
-  .coming-soon h3 { font-size: 15px; font-weight: 600; color: var(--text-faint); margin: 0; }
-  .coming-soon p { font-size: 13px; color: var(--text-placeholder); margin: 0; } */
+  .coming-soon h3 { font-size: 15px; font-weight: 600; color: var(--text-secondary); margin: 0; }
+  .coming-soon p { font-size: 13px; color: var(--text-muted); margin: 0; } */
 
   /* Loading block */
   .loading { display: flex; align-items: center; justify-content: center; gap: 12px; height: 100%; color: var(--text-link-muted); font-size: 14px; }
@@ -260,6 +260,6 @@
   /* Not-Shopify block */
   .not-shopify { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 8px; text-align: center; }
   .not-shopify__icon { width: 28px; height: 28px; color: var(--text-disabled); stroke-width: 1.7; }
-  .not-shopify h3 { font-size: 15px; font-weight: 600; color: var(--text-faint); margin: 0; }
-  .not-shopify p { font-size: 13px; color: var(--text-placeholder); margin: 0; }
+  .not-shopify h3 { font-size: 15px; font-weight: 600; color: var(--text-secondary); margin: 0; }
+  .not-shopify p { font-size: 13px; color: var(--text-muted); margin: 0; }
 </style>

--- a/entrypoints/popup/Assets.svelte
+++ b/entrypoints/popup/Assets.svelte
@@ -468,7 +468,7 @@
   .dropdown__trigger:hover { border-color: var(--border-hover); color: var(--text-secondary); }
   .dropdown__count { color: var(--text-muted); font-weight: 500; }
   .dropdown__chevron { width: 12px; height: 12px; stroke-width: 2; color: var(--text-muted); }
-  .dropdown__menu { position: absolute; top: calc(100% + 4px); left: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08); z-index: 10; min-width: 160px; padding: 4px; }
+  .dropdown__menu { position: absolute; top: calc(100% + 4px); left: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: var(--shadow-pop); z-index: 10; min-width: 160px; padding: 4px; }
   .dropdown__item { display: flex; align-items: center; justify-content: space-between; width: 100%; padding: 6px 10px; border: none; background: none; font-family: inherit; font-size: 12.5px; font-weight: 500; color: var(--text-secondary); cursor: pointer; border-radius: 5px; transition: background 0.1s; }
   .dropdown__item:hover { background: var(--bg-hover); }
   .dropdown__item--active { color: var(--text); font-weight: 600; }
@@ -484,7 +484,7 @@
   .export__trigger:hover { border-color: var(--border-hover); color: var(--text-secondary); }
   .export__icon { width: 13px; height: 13px; flex-shrink: 0; stroke-width: 1.8; }
   .export__chevron { width: 10px; height: 10px; stroke-width: 2; opacity: 0.6; }
-  .export__menu { position: absolute; top: calc(100% + 4px); right: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08); z-index: 10; min-width: 150px; padding: 4px; }
+  .export__menu { position: absolute; top: calc(100% + 4px); right: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: var(--shadow-pop); z-index: 10; min-width: 150px; padding: 4px; }
   .export__item { display: flex; align-items: center; justify-content: space-between; width: 100%; padding: 6px 10px; border: none; background: none; font-family: inherit; font-size: 12px; cursor: pointer; border-radius: 5px; transition: background 0.1s; }
   .export__item:hover { background: var(--bg-hover); }
   .export__item-label { font-weight: 600; color: var(--text); }
@@ -521,7 +521,7 @@
 
   .table { width: 100%; border-collapse: collapse; font-size: 13px; table-layout: fixed; }
 
-  .th { text-align: left; font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-label); padding: 8px 8px 8px 0; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--bg); z-index: 1; }
+  .th { text-align: left; font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-label); padding: 8px 8px 8px 0; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--bg-canvas); z-index: 1; }
   .th--num { width: 30px; padding-right: 0; }
   .th--size { width: 64px; }
   .th--time { width: 58px; }

--- a/entrypoints/popup/Headings.svelte
+++ b/entrypoints/popup/Headings.svelte
@@ -200,13 +200,8 @@
   .tree__row--has-issue { background: color-mix(in srgb, var(--error-bg) 50%, transparent); }
   .tree__row--has-issue:hover { background: var(--error-bg); }
 
-  .tree__badge { font-family: 'SF Mono', ui-monospace, monospace; font-size: 10px; font-weight: 600; padding: 1px 5px; border-radius: 3px; flex-shrink: 0; line-height: 16px; }
-  .tree__badge--h1 { background: var(--text); color: var(--bg); }
-  .tree__badge--h2 { background: var(--text-secondary); color: var(--bg); }
-  .tree__badge--h3 { background: var(--text-muted); color: var(--bg); }
-  .tree__badge--h4 { background: var(--border-strong); color: var(--text-secondary); }
-  .tree__badge--h5 { background: var(--bg-inset); color: var(--text-muted); border: 1px solid var(--border); }
-  .tree__badge--h6 { background: var(--bg-inset); color: var(--text-faint); border: 1px solid var(--border); }
+  /* Uniform indigo pill for all levels; depth is shown by indentation (per mockup) */
+  .tree__badge { font-family: inherit; font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 6px; flex-shrink: 0; line-height: 16px; background: var(--accent-tint); color: var(--accent); }
 
   .tree__text { font-size: 12.5px; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
   .tree__text--empty { font-style: italic; color: var(--text-disabled); }

--- a/entrypoints/popup/Links.svelte
+++ b/entrypoints/popup/Links.svelte
@@ -397,7 +397,7 @@
   .dropdown__trigger--active { border-color: var(--accent); }
   .dropdown__count { color: var(--text-muted); font-weight: 500; }
   .dropdown__chevron { width: 12px; height: 12px; stroke-width: 2; color: var(--text-muted); }
-  .dropdown__menu { position: absolute; top: calc(100% + 4px); left: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08); z-index: 10; min-width: 160px; padding: 4px; }
+  .dropdown__menu { position: absolute; top: calc(100% + 4px); left: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: var(--shadow-pop); z-index: 10; min-width: 160px; padding: 4px; }
   .dropdown__item { display: flex; align-items: center; justify-content: space-between; width: 100%; padding: 6px 10px; border: none; background: none; font-family: inherit; font-size: 12.5px; font-weight: 500; color: var(--text-secondary); cursor: pointer; border-radius: 5px; transition: background 0.1s; }
   .dropdown__item:hover { background: var(--bg-hover); }
   .dropdown__item--active { color: var(--text); font-weight: 600; }
@@ -412,7 +412,7 @@
   .export__trigger:hover { border-color: var(--border-hover); color: var(--text-secondary); }
   .export__icon { width: 13px; height: 13px; flex-shrink: 0; stroke-width: 1.8; }
   .export__chevron { width: 10px; height: 10px; stroke-width: 2; opacity: 0.6; }
-  .export__menu { position: absolute; top: calc(100% + 4px); right: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08); z-index: 10; min-width: 150px; padding: 4px; }
+  .export__menu { position: absolute; top: calc(100% + 4px); right: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: var(--shadow-pop); z-index: 10; min-width: 150px; padding: 4px; }
   .export__item { display: flex; align-items: center; justify-content: space-between; width: 100%; padding: 6px 10px; border: none; background: none; font-family: inherit; font-size: 12px; cursor: pointer; border-radius: 5px; transition: background 0.1s; }
   .export__item:hover { background: var(--bg-hover); }
   .export__item-label { font-weight: 600; color: var(--text); }
@@ -449,7 +449,7 @@
 
   .table { width: 100%; border-collapse: collapse; font-size: 13px; table-layout: fixed; }
 
-  .th { text-align: left; font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-label); padding: 8px 8px 8px 0; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--bg); z-index: 1; }
+  .th { text-align: left; font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-label); padding: 8px 8px 8px 0; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--bg-canvas); z-index: 1; }
   .th--num { width: 30px; padding-right: 0; }
   .th--follow { width: 76px; }
   .th--type { width: 76px; }

--- a/entrypoints/popup/Theme.svelte
+++ b/entrypoints/popup/Theme.svelte
@@ -203,7 +203,7 @@
     <div class="section__title">Preview URL</div>
     <div class="preview">
       <div class="preview__url">
-        <svg viewBox="0 0 24 24" fill="none" stroke="#929292" stroke-width="1.7" stroke-linecap="round" class="preview__icon"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" class="preview__icon"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
         <input
           class="preview__input"
           value={getThemePreviewUrl(storeInfo, disablePreviewBar)}
@@ -417,7 +417,7 @@
   .hero::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 140px; background: var(--hero-gradient); border-bottom: 1px solid var(--border); }
   .hero__identity { position: relative; display: flex; align-items: flex-end; gap: 20px; padding-bottom: 24px; }
   .hero__meta { flex: 1; min-width: 0; padding-bottom: 2px; }
-  .hero__name { font-size: 28px; font-weight: 400; color: var(--text); letter-spacing: -0.02em; line-height: 1.1; margin: 0; }
+  .hero__name { font-size: 24px; font-weight: 600; color: var(--text); letter-spacing: -0.02em; line-height: 1.15; margin: 0; }
   .hero__byline { display: flex; align-items: center; gap: 6px; margin-top: 5px; font-size: 12.5px; color: var(--text-muted); }
   .hero__byline-dot { width: 3px; height: 3px; border-radius: 50%; background: var(--text-muted); opacity: 0.5; }
   .hero__developer-link { color: var(--text-secondary); text-decoration: underline; text-decoration-color: var(--text-muted); text-underline-offset: 2px; transition: text-decoration-color 0.12s; }
@@ -467,7 +467,7 @@
   /* Preview block */
   .preview { border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
   .preview__url { display: flex; align-items: center; gap: 8px; padding: 10px 14px; }
-  .preview__icon { width: 14px; height: 14px; flex-shrink: 0; }
+  .preview__icon { width: 14px; height: 14px; flex-shrink: 0; color: var(--text-muted); }
   .preview__input { flex: 1; border: none; background: none; font-family: 'SF Mono', ui-monospace, monospace; font-size: 12px; color: var(--text-secondary); outline: none; min-width: 0; cursor: default; }
   .preview__copy { display: flex; align-items: center; gap: 4px; padding: 0 8px; height: 28px; font-size: 11px; font-weight: 600; flex-shrink: 0; border-radius: 6px; }
   .preview__copy-icon { width: 13px; height: 13px; stroke-width: 1.8; flex-shrink: 0; }

--- a/entrypoints/popup/Tooltip.svelte
+++ b/entrypoints/popup/Tooltip.svelte
@@ -29,7 +29,7 @@
   .trigger svg { width: 14px; height: 14px; color: var(--text-placeholder); transition: color 0.12s; }
   .trigger:hover svg { color: var(--text-muted); }
 
-  .tip { position: absolute; bottom: calc(100% + 8px); right: -8px; width: 220px; padding: 10px 12px; font-size: 12px; font-weight: 400; line-height: 1.55; color: var(--text-secondary); background: var(--bg); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08); pointer-events: none; z-index: 100; }
+  .tip { position: absolute; bottom: calc(100% + 8px); right: -8px; width: 220px; padding: 10px 12px; font-size: 12px; font-weight: 400; line-height: 1.55; color: var(--text-secondary); background: var(--bg); border: 1px solid var(--border); border-radius: 8px; box-shadow: var(--shadow-pop); pointer-events: none; z-index: 100; }
   .tip__title { display: block; font-size: 12px; font-weight: 600; color: var(--text); margin-bottom: 4px; }
   .tip__arrow { position: absolute; bottom: -6px; right: 10px; width: 10px; height: 10px; background: var(--bg); border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); transform: rotate(45deg); }
 </style>

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -7,71 +7,79 @@
     <meta name="manifest.type" content="browser_action" />
     <style>
       :root {
-        /* Backgrounds */
-        --bg: #fff;
-        --bg-raised: #fafafa;
-        --bg-inset: #f5f5f5;
-        --bg-hover: #f0f0f0;
+        /* Backgrounds: sidebar recedes < canvas < cards lift; insets recede */
+        --bg: #fff; /* cards, active tab, inputs, dropdowns (the lift surface) */
+        --bg-canvas: #fbfcfd; /* popup + content base: soft off-white, eases glare */
+        --bg-raised: #f4f6f8; /* sidebar / footers / code (recede) */
+        --bg-inset: #eef1f5; /* wells: chips, tracks, h5/h6 badges */
+        --bg-hover: #e9edf3;
 
         /* Borders */
-        --border: #f0f0f0;
-        --border-subtle: #f5f5f5;
-        --border-muted: #f8f8f8;
-        --border-hover: #ddd;
-        --border-strong: #ebebeb;
+        --border: #e9eaef;
+        --border-subtle: #eef0f3;
+        --border-muted: #f2f3f6;
+        --border-hover: #ccd0d8;
+        --border-strong: #dadde3;
 
-        /* Text */
-        --text: #111;
-        --text-secondary: #555;
-        --text-muted: #929292;
-        --text-faint: #bbb;
-        --text-disabled: #d0d0d0;
-        --text-placeholder: #ccc;
+        /* Text: distinct, ordered tiers, all AA on white (faint = decorative tier) */
+        --text: #1d1d22;
+        --text-secondary: #4d515b;
+        --text-muted: #656b78;
+        --text-faint: #828892;
+        --text-disabled: #b3b8c0;
+        --text-placeholder: #8b909b;
 
-        /* Interactive */
-        --text-link: #777;
-        --text-link-hover: #444;
-        --text-link-muted: #999;
-        --text-link-muted-hover: #666;
-        --text-label: #8a8a8a;
+        /* Interactive (sidebar tabs = muted gray) */
+        --text-link: #656b78;
+        --text-link-hover: #3a3e47;
+        --text-link-muted: #656b78;
+        --text-link-muted-hover: #4d515b;
+        --text-label: #656b78;
 
-        /* Accent */
-        --accent: #95bf47;
+        /* Accent: calm desaturated indigo = the interactive role
+           (green is reserved for the brand logo + success semantics) */
+        --accent: #4f57c4;
+        --accent-strong: #3f47b3;
+        --accent-tint: #eef0fb;
 
         /* Buttons */
-        --btn-bg: #111;
-        --btn-bg-hover: #333;
+        --btn-bg: #1d1d22;
+        --btn-bg-hover: #34343c;
         --btn-text: #fff;
 
-        /* Semantic: success */
-        --success: #22c55e;
-        --success-strong: #16a34a;
-        --success-bg: #dcfce7;
+        /* Semantic: success (muted green, AA on tint) */
+        --success: #1a9d51;
+        --success-strong: #15783f;
+        --success-bg: #e7f5ec;
 
-        /* Semantic: warning */
-        --warning: #ca8a04;
-        --warning-bg: #fffbeb;
+        /* Semantic: warning (amber, AA on tint) */
+        --warning: #9a5a08;
+        --warning-bg: #f9f0db;
 
-        /* Semantic: error */
-        --error: #ef4444;
-        --error-strong: #dc2626;
-        --error-bg: #fee2e2;
+        /* Semantic: error (muted red, AA on tint) */
+        --error: #c8362f;
+        --error-strong: #b42f28;
+        --error-bg: #fcebe9;
 
         /* Stars */
         --star-active: #fbbf24;
-        --star-inactive: #e0e0e0;
+        --star-inactive: #e2e4e9;
 
         /* Scrollbar */
-        --scrollbar: #e0e0e0;
+        --scrollbar: #d2d5dd;
 
-        /* Shadows */
-        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
-        --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.03);
-        --shadow-tab: 0 1px 3px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0, 0, 0, 0.03);
-        --shadow-knob: 0 1px 2px rgba(0, 0, 0, 0.1);
+        /* Focus ring (a11y) */
+        --ring: 0 0 0 3px rgba(79, 87, 196, 0.28);
 
-        /* Gradient */
-        --hero-gradient: linear-gradient(135deg, #fafafa 0%, #f5f5f5 50%, #f0f0f0 100%);
+        /* Shadows: cool-tinted, soft (no pure black) */
+        --shadow-sm: 0 1px 2px rgba(28, 28, 46, 0.05);
+        --shadow-md: 0 2px 8px rgba(28, 28, 46, 0.04);
+        --shadow-tab: 0 1px 2px rgba(28, 28, 46, 0.06), 0 0 0 1px rgba(28, 28, 46, 0.04);
+        --shadow-knob: 0 1px 3px rgba(28, 28, 46, 0.16);
+        --shadow-pop: 0 6px 20px rgba(28, 28, 46, 0.1); /* dropdowns, tooltips */
+
+        /* Gradient: subtle cool, lighter than the old gray band */
+        --hero-gradient: linear-gradient(135deg, #f3f5f8 0%, #eef1f6 55%, #f5f7f9 100%);
       }
 
       html,
@@ -82,6 +90,24 @@
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+      }
+
+      /* Accessibility: visible keyboard focus on interactive elements */
+      :focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      /* Accessibility: honor reduced-motion (collapse entrance + loop animation) */
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.001ms !important;
+          animation-iteration-count: 1 !important;
+          animation-delay: 0ms !important;
+          transition-duration: 0.001ms !important;
+        }
       }
     </style>
   </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.06.01",
+  "version": "2026.06.01.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     name: 'Alfred - Shopify Theme Detector',
     description:
       'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.06.01',
+    version: '2026.06.01.1',
     action: {
       default_title: 'Alfred'
     },


### PR DESCRIPTION
## Summary
A visual refresh of the extension popup focused on legibility and a soothing feel. Purely presentational, with no behavioral or feature changes.

### Palette and surfaces
- One calm desaturated indigo (#4f57c4) now carries every interactive element (links/URLs, active filters, toggle, focus). Green stays reserved for the Shopify brand mark and success semantics, so the two no longer compete.
- Every text tier was raised to meet WCAG AA contrast while keeping a clear, distinct hierarchy.
- A soft off-white canvas (--bg-canvas) lets white cards lift cleanly; sidebar and inset surfaces are cooler and shadows are softer (cool-tinted, no pure black).
- Semantic pills (success, warning, error) harmonized to AA-legible muted tones.

### Components
- Headings: uniform indigo level pills (depth shown by indentation) replace the gray ramp.
- Theme: crisper hero title (24px/600) and a tokenized preview icon color.
- Crisp active sidebar tab (real font-weight instead of a fuzzy text-shadow).
- Dropdown and tooltip popover shadows tokenized to one soft token.
- Added global reduced-motion support and keyboard focus rings; raised the "Not a Shopify store" empty-state text to AA.

## Verification
- Built a real-CSS preview harness (designs/popup-preview.html) and rendered every tab and state (Theme, Headings, Links, Assets, Settings, plus empty/loading/not-Shopify) to review the assembled result, not just isolated tokens.
- All text/background pairs verified at WCAG AA by contrast calculation; the gray hierarchy steps are preserved.
- Gates: tsc --noEmit clean, oxlint clean (only pre-existing unrelated warnings), oxfmt --check clean.

## Notes
- One deliberately accepted gap: resting form-control borders stay soft (below the 3:1 of WCAG 1.4.11 non-text contrast), chosen for the calm aesthetic. Text contrast (1.4.3) is full AA.
- No test suite in this project; changes are CSS and markup only.