### PR TITLE
v2026.06.10 feat(options): Shopify Admin Access Token Generator

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,28 @@
 [
   {
+    "version": "2026.06.10",
+    "date": "2026-06-10",
+    "changes": [
+      {
+        "type": "heading",
+        "content": "Admin Access Token Generator"
+      },
+      {
+        "type": "paragraph",
+        "content": "Skip the OAuth dance. The new Access Tokens page in Alfred’s settings generates Shopify Admin API access tokens for your custom apps in seconds — no Postman, no manually copying authorization codes before they expire."
+      },
+      {
+        "type": "list",
+        "content": [
+          "Pick API scopes from a searchable checklist, or use quick-select bundles like Read all, Theme development, and Orders read-only.",
+          "Alfred opens the approval screen, captures the redirect automatically, and exchanges the code for a token — even when the redirect points at localhost.",
+          "Generated tokens land in a local token vault: copy with one click, see granted scopes and age, delete individually or all at once.",
+          "Tokens and client secrets never leave your browser. Secrets are only held while the authorization is in flight, and tokens are excluded from any export."
+        ]
+      }
+    ]
+  },
+  {
     "version": "2026.06.09",
     "date": "2026-06-09",
     "changes": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026.06.10
+@ 2026-06-10
+
+### Admin Access Token Generator
+Skip the OAuth dance. The new Access Tokens page in Alfred’s settings generates Shopify Admin API access tokens for your custom apps in seconds — no Postman, no manually copying authorization codes before they expire.
+
+- Pick API scopes from a searchable checklist, or use quick-select bundles like Read all, Theme development, and Orders read-only.
+- Alfred opens the approval screen, captures the redirect automatically, and exchanges the code for a token — even when the redirect points at localhost.
+- Generated tokens land in a local token vault: copy with one click, see granted scopes and age, delete individually or all at once.
+- Tokens and client secrets never leave your browser. Secrets are only held while the authorization is in flight, and tokens are excluded from any export.
+
 ## 2026.06.09
 @ 2026-06-09
 
@@ -15,7 +26,7 @@ New Images tab in the popup audits every image on any page — for SEO, accessib
 - Export everything as CSV or JSON, or copy all image URLs to your clipboard.
 - Works on any website, not just Shopify stores.
 
-<video controls autoplay loop muted playsinline src="https://bucket.alfred.uptek.com/alfred-images.mp4"></video>
+<video controls muted playsinline src="https://bucket.alfred.uptek.com/alfred-images.mp4"></video>
 
 ## 2026.06.01.1
 @ 2026-06-01

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -1,4 +1,5 @@
 import { storage } from '#imports';
+import { registerOAuthHandler } from './oauth';
 import { registerShortcuts } from './shortcuts';
 import { trackAction, type AnalyticsAction } from '@/utils/analytics';
 import { saveReturnUrl, isValidReturnUrl } from '@/utils/storefrontPasswordRedirect';
@@ -53,6 +54,9 @@ export default defineBackground(() => {
   let currentShortcuts: unknown = null;
 
   registerShortcuts();
+
+  // Capture OAuth redirects for the Access Token Generator
+  registerOAuthHandler();
 
   // Re-register shortcuts when settings change
   storage.watch<AlfredSettings>('local:settings', (newValue) => {

--- a/entrypoints/background/oauth.ts
+++ b/entrypoints/background/oauth.ts
@@ -1,0 +1,103 @@
+import {
+  addStoredToken,
+  clearPendingSession,
+  exchangeCodeForToken,
+  getPendingSession,
+  isOAuthRedirect,
+  type OAuthResult,
+  type StoredAccessToken
+} from '@/utils/oauth';
+import { trackAction } from '@/utils/analytics';
+
+/**
+ * Capture the redirect leg of the Access Token Generator's OAuth flow.
+ *
+ * After the user approves the app on Shopify, the browser navigates to the
+ * app's redirect URI (conventionally http://localhost/) carrying ?code= and
+ * ?state=. Nothing usually listens there, but onBeforeNavigate fires before
+ * any connection attempt, so the code is captured even when the navigation
+ * itself ends in a connection error.
+ */
+export function registerOAuthHandler(): void {
+  browser.webNavigation.onBeforeNavigate.addListener((details) => {
+    if (details.frameId !== 0) return;
+    void handleNavigation(details.tabId, details.url);
+  });
+}
+
+async function handleNavigation(tabId: number, url: string): Promise<void> {
+  let navigated: URL;
+  try {
+    navigated = new URL(url);
+  } catch {
+    return;
+  }
+
+  // Cheap pre-filter so most navigations skip the storage read
+  const params = navigated.searchParams;
+  if (!params.has('code') && !params.has('error')) return;
+
+  const session = await getPendingSession();
+  if (!session) return;
+  if (!isOAuthRedirect(url, session.redirectUri)) return;
+
+  // The state param is the CSRF guard, and it doubles as proof that this
+  // navigation is actually our callback: Shopify echoes it on both success
+  // and denial. A forged callback or an unrelated navigation to the redirect
+  // URI is ignored entirely, leaving the real flow able to complete.
+  if (params.get('state') !== session.state) return;
+
+  // This is our callback. Delete the session now so the client secret's
+  // lifetime in storage ends here, whatever happens next.
+  await clearPendingSession();
+
+  if (params.get('error')) {
+    await finishFlow(tabId, 'denied');
+    return;
+  }
+
+  // Shopify includes the shop domain in the callback; if it's present and
+  // not the store this session targets, something is off.
+  const shop = params.get('shop');
+  if (shop && shop !== session.store) {
+    await finishFlow(tabId, 'state_mismatch');
+    return;
+  }
+
+  const code = params.get('code');
+  if (!code) {
+    await finishFlow(tabId, 'exchange_failed');
+    return;
+  }
+
+  try {
+    const { token, scopes } = await exchangeCodeForToken(session, code);
+
+    const storedToken: StoredAccessToken = {
+      id: crypto.randomUUID(),
+      store: session.store,
+      token,
+      scopes,
+      createdAt: Date.now()
+    };
+
+    await addStoredToken(storedToken);
+    trackAction('generate_access_token', { store_domain: session.store }).catch(() => {});
+    await finishFlow(tabId, 'success');
+  } catch (error) {
+    await finishFlow(
+      tabId,
+      error instanceof Error && error.message === 'exchange_failed' ? 'exchange_failed' : 'network_error'
+    );
+  }
+}
+
+/** Send the OAuth tab back to the options page with the outcome. */
+async function finishFlow(tabId: number, result: OAuthResult): Promise<void> {
+  const optionsUrl = browser.runtime.getURL(`/options.html?page=access-tokens&oauth=${result}`);
+  try {
+    await browser.tabs.update(tabId, { url: optionsUrl });
+  } catch {
+    // Tab already closed — the options page still picks up the token via storage.watch
+  }
+}

--- a/entrypoints/options/App.svelte
+++ b/entrypoints/options/App.svelte
@@ -2,6 +2,7 @@
   import Navigation from './components/Navigation.svelte';
   import Settings from './components/pages/Settings.svelte';
   import Changelog from './components/pages/Changelog.svelte';
+  import AccessTokens from './components/pages/AccessTokens.svelte';
 
   let currentPage = $state('settings');
   let isLoading = $state(true);
@@ -9,7 +10,7 @@
   $effect(() => {
     const params = new URLSearchParams(window.location.search);
     const page = params.get('page');
-    if (page && ['settings', 'changelog'].includes(page)) {
+    if (page && ['settings', 'changelog', 'access-tokens'].includes(page)) {
       currentPage = page;
     }
 
@@ -56,6 +57,8 @@
         <s-box>
           {#if currentPage === 'settings'}
             <Settings />
+          {:else if currentPage === 'access-tokens'}
+            <AccessTokens />
           {:else if currentPage === 'changelog'}
             <Changelog />
           {/if}

--- a/entrypoints/options/components/Navigation.svelte
+++ b/entrypoints/options/components/Navigation.svelte
@@ -10,6 +10,7 @@
 
   const navItems: NavItem[] = [
     { id: 'settings', label: 'Settings', icon: 'settings' },
+    { id: 'access-tokens', label: 'Access Tokens', icon: 'key' },
     { id: 'changelog', label: 'Changelog', icon: 'clock' },
     { id: 'feedback', label: 'Feedback & Requests', icon: 'lightbulb', url: 'https://github.com/uptek/alfred/issues' }
   ];

--- a/entrypoints/options/components/access-tokens/TokenGenerator.svelte
+++ b/entrypoints/options/components/access-tokens/TokenGenerator.svelte
@@ -1,0 +1,241 @@
+<script lang="ts">
+  import { storage } from '#imports';
+  import { ADMIN_SCOPES, SCOPE_BUNDLES, type ScopeBundle } from '@/utils/adminScopes';
+  import {
+    buildAuthorizationUrl,
+    clearPendingSession,
+    DEFAULT_REDIRECT_URI,
+    getPendingSession,
+    normalizeStoreDomain,
+    PENDING_SESSION_KEY,
+    savePendingSession,
+    type PendingOAuthSession
+  } from '@/utils/oauth';
+
+  let storeDomain = $state('');
+  let clientId = $state('');
+  let clientSecret = $state('');
+  let redirectUri = $state(DEFAULT_REDIRECT_URI);
+  let selectedScopes = $state.raw<Set<string>>(new Set());
+  let scopeSearch = $state('');
+  let formError = $state('');
+  let isLaunching = $state(false);
+  let pendingStore = $state<string | null>(null);
+
+  $effect(() => {
+    let alive = true;
+
+    getPendingSession().then((session) => {
+      if (alive) pendingStore = session?.store ?? null;
+    });
+
+    // The background deletes the session once the flow concludes
+    const unwatch = storage.watch<PendingOAuthSession>(PENDING_SESSION_KEY, (session) => {
+      pendingStore = session?.store ?? null;
+    });
+
+    return () => {
+      alive = false;
+      unwatch();
+    };
+  });
+
+  const filteredScopes = $derived.by(() => {
+    const query = scopeSearch.trim().toLowerCase();
+    if (!query) return ADMIN_SCOPES;
+    return ADMIN_SCOPES.filter(
+      (s) =>
+        s.handle.includes(query) ||
+        s.label.toLowerCase().includes(query) ||
+        s.group.toLowerCase().includes(query)
+    );
+  });
+
+  const scopeGroups = $derived.by(() => {
+    const groups = new Map<string, typeof ADMIN_SCOPES>();
+    for (const scope of filteredScopes) {
+      const group = groups.get(scope.group);
+      if (group) group.push(scope);
+      else groups.set(scope.group, [scope]);
+    }
+    return [...groups.entries()];
+  });
+
+  function toggleScope(handle: string) {
+    const next = new Set(selectedScopes);
+    if (next.has(handle)) next.delete(handle);
+    else next.add(handle);
+    selectedScopes = next;
+  }
+
+  function applyBundle(bundle: ScopeBundle) {
+    selectedScopes = new Set(bundle.scopes);
+  }
+
+  function clearScopes() {
+    selectedScopes = new Set();
+  }
+
+  async function handleCancelPending() {
+    await clearPendingSession();
+    pendingStore = null;
+  }
+
+  async function handleGenerate() {
+    formError = '';
+
+    const domain = normalizeStoreDomain(storeDomain);
+    if (!domain) {
+      formError = 'Enter a valid store domain (mystore or mystore.myshopify.com).';
+      return;
+    }
+    if (!clientId.trim() || !clientSecret.trim()) {
+      formError = 'Client ID and client secret are required.';
+      return;
+    }
+    if (!URL.canParse(redirectUri.trim())) {
+      formError = 'Redirect URI must be a valid URL.';
+      return;
+    }
+    if (selectedScopes.size === 0) {
+      formError = 'Select at least one scope.';
+      return;
+    }
+
+    isLaunching = true;
+    try {
+      const session: PendingOAuthSession = {
+        state: crypto.randomUUID(),
+        store: domain,
+        clientId: clientId.trim(),
+        clientSecret: clientSecret.trim(),
+        redirectUri: redirectUri.trim(),
+        scopes: [...selectedScopes],
+        createdAt: Date.now()
+      };
+
+      await savePendingSession(session);
+      await browser.tabs.create({ url: buildAuthorizationUrl(session) });
+
+      // The secret now lives only in the pending session until the
+      // background completes the exchange and deletes it; the session
+      // watcher picks up the new pending state.
+      clientSecret = '';
+    } catch (error) {
+      console.error('Failed to start OAuth flow:', error);
+      formError = 'Failed to start the authorization flow. Please try again.';
+    } finally {
+      isLaunching = false;
+    }
+  }
+</script>
+
+<s-section heading="Generate access token">
+  <s-paragraph>
+    Automates the Shopify OAuth flow for custom apps: pick scopes, approve the install, and the token
+    appears below. The client secret is only kept while the authorization is in flight and is discarded
+    as soon as the flow finishes.
+  </s-paragraph>
+
+  {#if formError}
+    <s-banner tone="critical">{formError}</s-banner>
+  {/if}
+
+  {#if pendingStore}
+    <s-banner tone="info">
+      Waiting for authorization on {pendingStore}. Approve the app in the Shopify tab, or
+      <s-link onclick={handleCancelPending}>cancel the pending flow</s-link>.
+    </s-banner>
+  {/if}
+
+  <s-grid gridTemplateColumns="1fr 1fr" gap="base">
+    <s-text-field
+      label="Store domain"
+      placeholder="mystore.myshopify.com"
+      value={storeDomain}
+      oninput={(e: Event) => (storeDomain = (e.target as HTMLInputElement).value)}
+    ></s-text-field>
+    <s-text-field
+      label="Redirect URI"
+      details="Must match an allowed redirection URL in the app's configuration."
+      value={redirectUri}
+      oninput={(e: Event) => (redirectUri = (e.target as HTMLInputElement).value)}
+    ></s-text-field>
+    <s-text-field
+      label="Client ID"
+      value={clientId}
+      oninput={(e: Event) => (clientId = (e.target as HTMLInputElement).value)}
+    ></s-text-field>
+    <s-password-field
+      label="Client secret"
+      details="Used once for the token exchange. Never stored."
+      value={clientSecret}
+      oninput={(e: Event) => (clientSecret = (e.target as HTMLInputElement).value)}
+    ></s-password-field>
+  </s-grid>
+
+  <div class="section-level-2">
+    <s-stack gap="small">
+      <s-stack direction="inline" alignItems="center" gap="small-200">
+        <s-text>Quick select:</s-text>
+        {#each SCOPE_BUNDLES as bundle (bundle.id)}
+          <s-button variant="secondary" onclick={() => applyBundle(bundle)}>{bundle.label}</s-button>
+        {/each}
+        <s-button variant="tertiary" onclick={clearScopes} disabled={selectedScopes.size === 0}>
+          Clear
+        </s-button>
+      </s-stack>
+
+      <s-text-field
+        label="Search scopes"
+        labelAccessibilityVisibility="exclusive"
+        placeholder="Search {ADMIN_SCOPES.length} scopes…"
+        value={scopeSearch}
+        oninput={(e: Event) => (scopeSearch = (e.target as HTMLInputElement).value)}
+      ></s-text-field>
+
+      <div class="scope-list">
+        {#each scopeGroups as [group, scopes] (group)}
+          <div class="scope-group">
+            <s-text color="subdued">{group}</s-text>
+            {#each scopes as scope (scope.handle)}
+              <s-checkbox
+                label={scope.label}
+                details={scope.handle}
+                checked={selectedScopes.has(scope.handle)}
+                onchange={() => toggleScope(scope.handle)}
+              ></s-checkbox>
+            {/each}
+          </div>
+        {:else}
+          <s-text color="subdued">No scopes match "{scopeSearch}".</s-text>
+        {/each}
+      </div>
+    </s-stack>
+  </div>
+
+  <s-stack direction="inline" justifyContent="space-between" alignItems="center">
+    <s-text color="subdued">
+      {selectedScopes.size}
+      {selectedScopes.size === 1 ? 'scope' : 'scopes'} selected
+    </s-text>
+    <s-button variant="primary" onclick={handleGenerate} loading={isLaunching}>Generate token</s-button>
+  </s-stack>
+</s-section>
+
+<style>
+  .scope-list {
+    max-height: 320px;
+    overflow-y: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 12px;
+    padding: 4px 0;
+  }
+
+  .scope-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+</style>

--- a/entrypoints/options/components/access-tokens/TokenVault.svelte
+++ b/entrypoints/options/components/access-tokens/TokenVault.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import { storage } from '#imports';
+  import {
+    ACCESS_TOKENS_KEY,
+    clearAllStoredTokens,
+    deleteStoredToken,
+    getStoredTokens,
+    type StoredAccessToken
+  } from '@/utils/oauth';
+  import { trackAction } from '@/utils/analytics';
+  import { formatTimeAgo } from '@/utils/helpers';
+  import { Toast } from '@/utils/toast';
+
+  let tokens = $state<StoredAccessToken[]>([]);
+  let loading = $state(true);
+
+  $effect(() => {
+    let alive = true;
+
+    getStoredTokens().then((stored) => {
+      if (!alive) return;
+      tokens = stored;
+      loading = false;
+    });
+
+    // The background writes new tokens after the OAuth exchange completes
+    const unwatch = storage.watch<StoredAccessToken[]>(ACCESS_TOKENS_KEY, (newTokens) => {
+      tokens = newTokens ?? [];
+    });
+
+    return () => {
+      alive = false;
+      unwatch();
+    };
+  });
+
+  function maskToken(token: string): string {
+    return `${token.slice(0, 10)}…${token.slice(-4)}`;
+  }
+
+  async function handleCopy(token: StoredAccessToken) {
+    try {
+      await navigator.clipboard.writeText(token.token);
+      Toast.success('Token copied to clipboard');
+      trackAction('copy_access_token').catch(() => {});
+    } catch {
+      Toast.error('Failed to copy token');
+    }
+  }
+
+  async function handleDelete(token: StoredAccessToken) {
+    if (!confirm(`Delete the access token for ${token.store}? This cannot be undone.`)) return;
+    try {
+      await deleteStoredToken(token.id);
+      Toast.success('Token deleted');
+      trackAction('delete_access_token').catch(() => {});
+    } catch {
+      Toast.error('Failed to delete token');
+    }
+  }
+
+  async function handleClearAll() {
+    if (!confirm(`Delete all ${tokens.length} access tokens? This cannot be undone.`)) return;
+    try {
+      await clearAllStoredTokens();
+      Toast.success('All tokens deleted');
+    } catch {
+      Toast.error('Failed to delete tokens');
+    }
+  }
+</script>
+
+<s-section heading="Token vault">
+  <s-paragraph>
+    Tokens are stored locally in your browser and are never synced or included in any export. Remember
+    to uninstall the app on stores you no longer work with — that revokes its tokens.
+  </s-paragraph>
+
+  {#if loading}
+    <div style="display: flex; justify-content: center; padding: 2rem;">
+      <s-spinner size="base"></s-spinner>
+    </div>
+  {:else if tokens.length === 0}
+    <s-banner tone="info">
+      No saved tokens yet. Generate one above and it will appear here automatically.
+    </s-banner>
+  {:else}
+    <s-stack direction="inline" justifyContent="end">
+      <s-button icon="delete" onclick={handleClearAll} tone="critical" variant="secondary">
+        Delete all
+      </s-button>
+    </s-stack>
+    <div class="section-level-2">
+      <s-table>
+        <s-table-header-row>
+          <s-table-header listSlot="primary">Store</s-table-header>
+          <s-table-header listSlot="secondary">Token</s-table-header>
+          <s-table-header>Scopes</s-table-header>
+          <s-table-header>Created</s-table-header>
+          <s-table-header></s-table-header>
+        </s-table-header-row>
+        <s-table-body>
+          {#each tokens as token (token.id)}
+            <s-table-row>
+              <s-table-cell>
+                <s-link href="https://{token.store}/admin" target="_blank">{token.store}</s-link>
+              </s-table-cell>
+              <s-table-cell>
+                <code class="token-mask">{maskToken(token.token)}</code>
+              </s-table-cell>
+              <s-table-cell>
+                <span title={token.scopes.join(', ')}>
+                  {token.scopes.length}
+                  {token.scopes.length === 1 ? 'scope' : 'scopes'}
+                </span>
+              </s-table-cell>
+              <s-table-cell>{formatTimeAgo(token.createdAt)}</s-table-cell>
+              <s-table-cell>
+                <s-stack direction="inline" gap="small-200">
+                  <s-button icon="clipboard" accessibilityLabel="Copy token" onclick={() => handleCopy(token)}
+                  ></s-button>
+                  <s-button
+                    icon="delete"
+                    accessibilityLabel="Delete token"
+                    onclick={() => handleDelete(token)}
+                    tone="critical"
+                  ></s-button>
+                </s-stack>
+              </s-table-cell>
+            </s-table-row>
+          {/each}
+        </s-table-body>
+      </s-table>
+    </div>
+  {/if}
+</s-section>
+
+<style>
+  .token-mask {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+  }
+</style>

--- a/entrypoints/options/components/access-tokens/TokenVault.svelte
+++ b/entrypoints/options/components/access-tokens/TokenVault.svelte
@@ -73,7 +73,7 @@
 <s-section heading="Token vault">
   <s-paragraph>
     Tokens are stored locally in your browser and are never synced or included in any export. Remember
-    to uninstall the app on stores you no longer work with — that revokes its tokens.
+    to uninstall the app on stores you no longer work with: that revokes its tokens.
   </s-paragraph>
 
   {#if loading}

--- a/entrypoints/options/components/pages/AccessTokens.svelte
+++ b/entrypoints/options/components/pages/AccessTokens.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import PageHeader from '../PageHeader.svelte';
+  import TokenGenerator from '../access-tokens/TokenGenerator.svelte';
+  import TokenVault from '../access-tokens/TokenVault.svelte';
+  import { Toast } from '@/utils/toast';
+  import { OAUTH_ERROR_MESSAGES, type OAuthResult } from '@/utils/oauth';
+
+  let flowError = $state('');
+
+  // The background redirects the OAuth tab here with ?oauth=<result>
+  $effect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const result = params.get('oauth');
+    if (!result) return;
+
+    if (result === 'success') {
+      Toast.success('Access token generated');
+    } else {
+      flowError =
+        OAUTH_ERROR_MESSAGES[result as Exclude<OAuthResult, 'success'>] ??
+        'Something went wrong during authorization.';
+    }
+
+    history.replaceState({ page: 'access-tokens' }, '', '?page=access-tokens');
+  });
+</script>
+
+<s-grid gap="base">
+  <PageHeader title="Access Tokens" icon="key" />
+
+  {#if flowError}
+    <s-banner tone="critical">{flowError}</s-banner>
+  {/if}
+
+  <TokenGenerator />
+  <TokenVault />
+</s-grid>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.06.09",
+  "version": "2026.06.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/utils/adminScopes.ts
+++ b/utils/adminScopes.ts
@@ -1,0 +1,200 @@
+/**
+ * Static registry of Shopify Admin API access scopes and quick-select bundles
+ * for the Access Token Generator.
+ *
+ * Source: https://shopify.dev/docs/api/usage/access-scopes
+ */
+
+export interface AdminScope {
+  /** Scope handle sent to Shopify, e.g. "read_products" */
+  handle: string;
+  /** Human-readable label, e.g. "Products (read)" */
+  label: string;
+  /** Group used to cluster scopes in the checklist UI */
+  group: string;
+}
+
+export interface ScopeBundle {
+  id: string;
+  label: string;
+  description: string;
+  scopes: string[];
+}
+
+export const ADMIN_SCOPES: AdminScope[] = [
+  // Products
+  { handle: 'read_products', label: 'Products (read)', group: 'Products' },
+  { handle: 'write_products', label: 'Products (write)', group: 'Products' },
+  { handle: 'read_product_listings', label: 'Product Listings (read)', group: 'Products' },
+  { handle: 'read_product_feeds', label: 'Product Feeds (read)', group: 'Products' },
+  { handle: 'write_product_feeds', label: 'Product Feeds (write)', group: 'Products' },
+  { handle: 'read_purchase_options', label: 'Purchase Options (read)', group: 'Products' },
+  { handle: 'write_purchase_options', label: 'Purchase Options (write)', group: 'Products' },
+  // Inventory
+  { handle: 'read_inventory', label: 'Inventory (read)', group: 'Inventory' },
+  { handle: 'write_inventory', label: 'Inventory (write)', group: 'Inventory' },
+  { handle: 'read_locations', label: 'Locations (read)', group: 'Inventory' },
+  // Orders
+  { handle: 'read_orders', label: 'Orders (read)', group: 'Orders' },
+  { handle: 'write_orders', label: 'Orders (write)', group: 'Orders' },
+  { handle: 'read_all_orders', label: 'All Orders, older than 60 days (read)', group: 'Orders' },
+  { handle: 'read_draft_orders', label: 'Draft Orders (read)', group: 'Orders' },
+  { handle: 'write_draft_orders', label: 'Draft Orders (write)', group: 'Orders' },
+  { handle: 'read_order_edits', label: 'Order Edits (read)', group: 'Orders' },
+  { handle: 'write_order_edits', label: 'Order Edits (write)', group: 'Orders' },
+  { handle: 'read_payment_terms', label: 'Payment Terms (read)', group: 'Orders' },
+  { handle: 'write_payment_terms', label: 'Payment Terms (write)', group: 'Orders' },
+  { handle: 'read_returns', label: 'Returns (read)', group: 'Orders' },
+  { handle: 'write_returns', label: 'Returns (write)', group: 'Orders' },
+  // Checkouts
+  { handle: 'read_checkouts', label: 'Checkouts (read)', group: 'Checkouts' },
+  { handle: 'write_checkouts', label: 'Checkouts (write)', group: 'Checkouts' },
+  // Customers
+  { handle: 'read_customers', label: 'Customers (read)', group: 'Customers' },
+  { handle: 'write_customers', label: 'Customers (write)', group: 'Customers' },
+  { handle: 'read_customer_events', label: 'Customer Events (read)', group: 'Customers' },
+  { handle: 'read_customer_payment_methods', label: 'Customer Payment Methods (read)', group: 'Customers' },
+  { handle: 'read_store_credit_accounts', label: 'Store Credit Accounts (read)', group: 'Customers' },
+  {
+    handle: 'read_store_credit_account_transactions',
+    label: 'Store Credit Transactions (read)',
+    group: 'Customers'
+  },
+  {
+    handle: 'write_store_credit_account_transactions',
+    label: 'Store Credit Transactions (write)',
+    group: 'Customers'
+  },
+  // B2B
+  { handle: 'read_companies', label: 'Companies (read)', group: 'B2B' },
+  { handle: 'write_companies', label: 'Companies (write)', group: 'B2B' },
+  // Discounts & Marketing
+  { handle: 'read_discounts', label: 'Discounts (read)', group: 'Discounts' },
+  { handle: 'write_discounts', label: 'Discounts (write)', group: 'Discounts' },
+  { handle: 'read_price_rules', label: 'Price Rules (read)', group: 'Discounts' },
+  { handle: 'write_price_rules', label: 'Price Rules (write)', group: 'Discounts' },
+  { handle: 'read_gift_cards', label: 'Gift Cards (read)', group: 'Marketing' },
+  { handle: 'write_gift_cards', label: 'Gift Cards (write)', group: 'Marketing' },
+  { handle: 'read_marketing_events', label: 'Marketing Events (read)', group: 'Marketing' },
+  { handle: 'write_marketing_events', label: 'Marketing Events (write)', group: 'Marketing' },
+  // Fulfillment & Shipping
+  { handle: 'read_fulfillments', label: 'Fulfillments (read)', group: 'Fulfillment' },
+  { handle: 'write_fulfillments', label: 'Fulfillments (write)', group: 'Fulfillment' },
+  {
+    handle: 'read_assigned_fulfillment_orders',
+    label: 'Assigned Fulfillment Orders (read)',
+    group: 'Fulfillment'
+  },
+  {
+    handle: 'write_assigned_fulfillment_orders',
+    label: 'Assigned Fulfillment Orders (write)',
+    group: 'Fulfillment'
+  },
+  {
+    handle: 'read_merchant_managed_fulfillment_orders',
+    label: 'Merchant-managed Fulfillment Orders (read)',
+    group: 'Fulfillment'
+  },
+  {
+    handle: 'write_merchant_managed_fulfillment_orders',
+    label: 'Merchant-managed Fulfillment Orders (write)',
+    group: 'Fulfillment'
+  },
+  {
+    handle: 'read_third_party_fulfillment_orders',
+    label: 'Third-party Fulfillment Orders (read)',
+    group: 'Fulfillment'
+  },
+  {
+    handle: 'write_third_party_fulfillment_orders',
+    label: 'Third-party Fulfillment Orders (write)',
+    group: 'Fulfillment'
+  },
+  { handle: 'read_shipping', label: 'Shipping (read)', group: 'Fulfillment' },
+  { handle: 'write_shipping', label: 'Shipping (write)', group: 'Fulfillment' },
+  // Themes & Content
+  { handle: 'read_themes', label: 'Themes (read)', group: 'Themes' },
+  { handle: 'write_themes', label: 'Themes (write)', group: 'Themes' },
+  { handle: 'read_content', label: 'Content (read)', group: 'Content' },
+  { handle: 'write_content', label: 'Content (write)', group: 'Content' },
+  { handle: 'read_files', label: 'Files (read)', group: 'Content' },
+  { handle: 'write_files', label: 'Files (write)', group: 'Content' },
+  { handle: 'read_publications', label: 'Publications (read)', group: 'Content' },
+  { handle: 'write_publications', label: 'Publications (write)', group: 'Content' },
+  { handle: 'read_script_tags', label: 'Script Tags (read)', group: 'Content' },
+  { handle: 'write_script_tags', label: 'Script Tags (write)', group: 'Content' },
+  { handle: 'read_translations', label: 'Translations (read)', group: 'Content' },
+  { handle: 'write_translations', label: 'Translations (write)', group: 'Content' },
+  // Metafields & Metaobjects
+  { handle: 'read_metaobject_definitions', label: 'Metaobject Definitions (read)', group: 'Metaobjects' },
+  { handle: 'write_metaobject_definitions', label: 'Metaobject Definitions (write)', group: 'Metaobjects' },
+  { handle: 'read_metaobjects', label: 'Metaobjects (read)', group: 'Metaobjects' },
+  { handle: 'write_metaobjects', label: 'Metaobjects (write)', group: 'Metaobjects' },
+  // Markets & Localization
+  { handle: 'read_markets', label: 'Markets (read)', group: 'Markets' },
+  { handle: 'write_markets', label: 'Markets (write)', group: 'Markets' },
+  { handle: 'read_locales', label: 'Locales (read)', group: 'Markets' },
+  { handle: 'write_locales', label: 'Locales (write)', group: 'Markets' },
+  // Analytics & Reports
+  { handle: 'read_analytics', label: 'Analytics (read)', group: 'Analytics' },
+  { handle: 'read_reports', label: 'Reports (read)', group: 'Analytics' },
+  { handle: 'write_reports', label: 'Reports (write)', group: 'Analytics' },
+  // Payments
+  { handle: 'read_shopify_payments_accounts', label: 'Shopify Payments Accounts (read)', group: 'Payments' },
+  {
+    handle: 'read_shopify_payments_bank_accounts',
+    label: 'Shopify Payments Bank Accounts (read)',
+    group: 'Payments'
+  },
+  { handle: 'read_shopify_payments_disputes', label: 'Shopify Payments Disputes (read)', group: 'Payments' },
+  { handle: 'read_shopify_payments_payouts', label: 'Shopify Payments Payouts (read)', group: 'Payments' },
+  // Store
+  { handle: 'read_legal_policies', label: 'Legal Policies (read)', group: 'Store' },
+  { handle: 'read_resource_feedback', label: 'Resource Feedback (read)', group: 'Store' },
+  { handle: 'write_resource_feedback', label: 'Resource Feedback (write)', group: 'Store' },
+  { handle: 'read_shopify_credit', label: 'Shopify Credit (read)', group: 'Store' }
+];
+
+export const SCOPE_BUNDLES: ScopeBundle[] = [
+  {
+    id: 'full_access',
+    label: 'Full access',
+    description: 'Every read and write scope. Use with caution.',
+    scopes: ADMIN_SCOPES.map((s) => s.handle)
+  },
+  {
+    id: 'read_all',
+    label: 'Read all',
+    description: 'Every read scope, no write access.',
+    scopes: ADMIN_SCOPES.filter((s) => s.handle.startsWith('read_')).map((s) => s.handle)
+  },
+  {
+    id: 'theme_development',
+    label: 'Theme development',
+    description: 'Themes, files, content, and translations.',
+    scopes: [
+      'read_themes',
+      'write_themes',
+      'read_files',
+      'write_files',
+      'read_content',
+      'write_content',
+      'read_translations',
+      'write_translations',
+      'read_products',
+      'read_locales'
+    ]
+  },
+  {
+    id: 'products_only',
+    label: 'Products only',
+    description: 'Products and inventory, read and write.',
+    scopes: ['read_products', 'write_products', 'read_inventory', 'write_inventory', 'read_locations']
+  },
+  {
+    id: 'orders_readonly',
+    label: 'Orders read-only',
+    description: 'Read access to orders, drafts, and fulfillments.',
+    scopes: ['read_orders', 'read_draft_orders', 'read_order_edits', 'read_fulfillments', 'read_returns']
+  }
+];

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -74,7 +74,10 @@ export type AnalyticsAction =
   | 'images_export'
   | 'images_copy'
   | 'images_sort'
-  | 'images_open';
+  | 'images_open'
+  | 'generate_access_token'
+  | 'copy_access_token'
+  | 'delete_access_token';
 
 // Time savings per action (in seconds)
 const TIME_SAVINGS: Record<AnalyticsAction, number | ((metadata?: Record<string, unknown>) => number)> = {
@@ -154,7 +157,10 @@ const TIME_SAVINGS: Record<AnalyticsAction, number | ((metadata?: Record<string,
   images_export: 60,
   images_copy: 60,
   images_sort: 25,
-  images_open: 5
+  images_open: 5,
+  generate_access_token: 300,
+  copy_access_token: 10,
+  delete_access_token: 0
 };
 
 // --- Usage Stats (local tracking) ---
@@ -251,7 +257,10 @@ const ACTION_CATEGORIES: Record<AnalyticsAction, string> = {
   images_export: 'SEO',
   images_copy: 'SEO',
   images_sort: 'SEO',
-  images_open: 'SEO'
+  images_open: 'SEO',
+  generate_access_token: 'Access Tokens',
+  copy_access_token: 'Access Tokens',
+  delete_access_token: 'Access Tokens'
 };
 
 /** Local usage stats persisted in `local:usage_stats`.

--- a/utils/oauth.ts
+++ b/utils/oauth.ts
@@ -1,0 +1,198 @@
+/**
+ * Shared logic for the Shopify Admin Access Token Generator (issue #47).
+ *
+ * The OAuth flow spans two contexts:
+ * - The options page builds the authorization URL, stores a pending session,
+ *   and opens the Shopify approval tab.
+ * - The background service worker captures the redirect back to the app's
+ *   redirect URI, exchanges the code for a token, and saves it to the vault.
+ *
+ * Both contexts import from this module so storage keys and data shapes have
+ * a single source of truth.
+ *
+ * Security notes:
+ * - The client secret only ever exists in the pending session, which is
+ *   deleted as soon as the redirect is captured (or after SESSION_EXPIRY_MS).
+ * - Tokens live in their own storage key (`local:access_tokens`) so they can
+ *   never leak through preset import/export, which uses separate keys.
+ */
+
+import { storage } from '#imports';
+
+export const PENDING_SESSION_KEY = 'local:oauth_pending_session';
+export const ACCESS_TOKENS_KEY = 'local:access_tokens';
+
+/** Shopify authorization codes expire after 10 minutes; so do our sessions. */
+export const SESSION_EXPIRY_MS = 10 * 60 * 1000;
+
+export const DEFAULT_REDIRECT_URI = 'http://localhost/';
+
+export interface PendingOAuthSession {
+  /** Random value sent as the OAuth `state` param and validated on redirect */
+  state: string;
+  /** Full myshopify domain, e.g. "mystore.myshopify.com" */
+  store: string;
+  clientId: string;
+  /** Held only while the flow is in flight; deleted with the session */
+  clientSecret: string;
+  redirectUri: string;
+  /** Requested scopes (the granted set comes back in the exchange response) */
+  scopes: string[];
+  createdAt: number;
+}
+
+export interface StoredAccessToken {
+  id: string;
+  /** Full myshopify domain */
+  store: string;
+  token: string;
+  /** Scopes actually granted, parsed from the exchange response */
+  scopes: string[];
+  createdAt: number;
+}
+
+/** Result codes surfaced to the options page via the `oauth` URL param. */
+export type OAuthResult = 'success' | 'denied' | 'state_mismatch' | 'exchange_failed' | 'network_error';
+
+/** User-facing messages for every non-success outcome of the OAuth flow. */
+export const OAUTH_ERROR_MESSAGES: Record<Exclude<OAuthResult, 'success'>, string> = {
+  denied: 'Authorization was declined on the Shopify approval screen.',
+  state_mismatch: 'Security check failed: the callback did not match the pending request. Please try again.',
+  exchange_failed: 'Token exchange failed. Double-check the client ID, client secret, and redirect URI.',
+  network_error: 'Network error during the token exchange. Please try again.'
+};
+
+// --- Pending session ---
+
+export async function savePendingSession(session: PendingOAuthSession): Promise<void> {
+  await storage.setItem<PendingOAuthSession>(PENDING_SESSION_KEY, session);
+}
+
+/**
+ * Get the in-flight OAuth session, if any. Expired sessions are cleared and
+ * reported as absent, which also guarantees the client secret never outlives
+ * SESSION_EXPIRY_MS in storage.
+ */
+export async function getPendingSession(): Promise<PendingOAuthSession | null> {
+  const session = await storage.getItem<PendingOAuthSession>(PENDING_SESSION_KEY);
+  if (!session) return null;
+
+  if (Date.now() - session.createdAt > SESSION_EXPIRY_MS) {
+    await clearPendingSession();
+    return null;
+  }
+
+  return session;
+}
+
+export async function clearPendingSession(): Promise<void> {
+  await storage.removeItem(PENDING_SESSION_KEY);
+}
+
+// --- Token vault ---
+
+export async function getStoredTokens(): Promise<StoredAccessToken[]> {
+  return (await storage.getItem<StoredAccessToken[]>(ACCESS_TOKENS_KEY)) ?? [];
+}
+
+export async function addStoredToken(token: StoredAccessToken): Promise<void> {
+  const tokens = await getStoredTokens();
+  await storage.setItem(ACCESS_TOKENS_KEY, [token, ...tokens]);
+}
+
+export async function deleteStoredToken(id: string): Promise<void> {
+  const tokens = await getStoredTokens();
+  await storage.setItem(
+    ACCESS_TOKENS_KEY,
+    tokens.filter((t) => t.id !== id)
+  );
+}
+
+export async function clearAllStoredTokens(): Promise<void> {
+  await storage.removeItem(ACCESS_TOKENS_KEY);
+}
+
+// --- URL helpers ---
+
+/**
+ * Normalize user input into a full myshopify domain.
+ * Accepts "mystore", "mystore.myshopify.com", or a pasted URL.
+ * @returns The normalized domain, or null if the input is not usable
+ */
+export function normalizeStoreDomain(raw: string): string | null {
+  const trimmed = raw
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/.*$/, '');
+
+  if (!trimmed) return null;
+
+  // Bare store handle, e.g. "mystore"
+  if (!trimmed.includes('.')) return `${trimmed}.myshopify.com`;
+
+  // Only myshopify domains can serve the OAuth endpoints
+  if (!trimmed.endsWith('.myshopify.com')) return null;
+
+  return trimmed;
+}
+
+export function buildAuthorizationUrl(session: PendingOAuthSession): string {
+  const params = new URLSearchParams({
+    client_id: session.clientId,
+    scope: session.scopes.join(','),
+    redirect_uri: session.redirectUri,
+    state: session.state
+  });
+  return `https://${session.store}/admin/oauth/authorize?${params.toString()}`;
+}
+
+/**
+ * Check whether a navigated URL is the OAuth callback for the given session.
+ * Matches on origin + path prefix so query params don't matter.
+ */
+export function isOAuthRedirect(url: string, redirectUri: string): boolean {
+  try {
+    const navigated = new URL(url);
+    const redirect = new URL(redirectUri);
+    return navigated.origin === redirect.origin && navigated.pathname.startsWith(redirect.pathname);
+  } catch {
+    return false;
+  }
+}
+
+// --- Token exchange ---
+
+/**
+ * Exchange an authorization code for an access token.
+ * Runs in the background service worker (host_permissions cover CORS).
+ * @throws Error('exchange_failed') on a non-OK or malformed response —
+ *   deliberately generic so credentials never end up in error messages
+ */
+export async function exchangeCodeForToken(
+  session: PendingOAuthSession,
+  code: string
+): Promise<{ token: string; scopes: string[] }> {
+  const response = await fetch(`https://${session.store}/admin/oauth/access_token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: session.clientId,
+      client_secret: session.clientSecret,
+      code
+    })
+  });
+
+  if (!response.ok) throw new Error('exchange_failed');
+
+  const data = (await response.json().catch(() => null)) as { access_token?: string; scope?: string } | null;
+  if (!data?.access_token) throw new Error('exchange_failed');
+
+  return {
+    token: data.access_token,
+    scopes: (data.scope ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  };
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     name: 'Alfred - Shopify Theme Detector',
     description:
       'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.06.09',
+    version: '2026.06.10',
     action: {
       default_title: 'Alfred'
     },


### PR DESCRIPTION
Closes #47

## What

Automates the Shopify Admin OAuth flow from inside the browser. A new **Access Tokens** page in the options app lets you enter a custom app's credentials, pick scopes from a searchable checklist (with quick-select bundles), and generate an Admin API access token without Postman or manual URL construction.

## How it works

1. The options page builds the `/admin/oauth/authorize` URL with a random `state` param, saves a pending session (`local:oauth_pending_session`), and opens the approval tab.
2. The background service worker captures the redirect via `webNavigation.onBeforeNavigate`: this fires before any connection attempt, so the `?code=` is captured even when the redirect URI is `http://localhost/` with nothing listening.
3. The `state` param is validated (CSRF guard + proof the navigation is our callback; unrelated navigations and forged callbacks are ignored without disturbing the in-flight session).
4. The background exchanges the code at `/admin/oauth/access_token` (CORS-free thanks to existing `<all_urls>` host permissions), saves the token to the vault, deletes the pending session, and redirects the tab back to the options page with the outcome.
5. The vault (`local:access_tokens`) lists tokens by store with granted scopes and age; one-click copy, per-token delete, and delete-all. The options page updates reactively via `storage.watch`.

## Security

- Client secret is held only in the pending session while the flow is in flight and is deleted the moment the callback is captured (or after the 10-minute expiry, matching Shopify's code lifetime).
- Tokens live in their own storage key, never synced and structurally excluded from preset import/export.
- Stored scopes are the **granted** set parsed from the exchange response, not the requested set.
- Generic error messages: credentials never appear in errors or logs.

## Scope (v1, per discussion)

Core flow + token vault, options page only. Deferred to follow-ups: user-saved scope presets, Partner Dashboard credential auto-detect, context-menu trigger.

## Changes

- `utils/oauth.ts`: shared types, session/vault storage, URL build/parse, token exchange
- `utils/adminScopes.ts`: static Admin API scope registry + quick-select bundles
- `entrypoints/background/oauth.ts`: redirect capture + exchange state machine
- `entrypoints/options/components/pages/AccessTokens.svelte`, `access-tokens/TokenGenerator.svelte`, `access-tokens/TokenVault.svelte`: new page UI (Polaris web components)
- Navigation/App routing, analytics actions, version bump to 2026.06.10 + changelog

## Testing

- `tsc --noEmit`, `oxlint`, `oxfmt` clean; production `wxt build` succeeds
- No new manifest permissions required
