### PR TITLE
feat(settings): add option to disable opening changelog on update

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "2026.06.17",
+    "date": "2026-06-17",
+    "changes": [
+      {
+        "type": "paragraph",
+        "content": "A new General setting lets you stop the changelog from opening in a new tab every time Alfred updates. It stays on by default, so nothing changes unless you turn it off."
+      }
+    ]
+  },
+  {
     "version": "2026.06.15",
     "date": "2026-06-15",
     "changes": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.06.17
+@ 2026-06-17
+A new General setting lets you stop the changelog from opening in a new tab every time Alfred updates. It stays on by default, so nothing changes unless you turn it off.
+
+
 ## 2026.06.15
 @ 2026-06-15
 

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -4,6 +4,7 @@ import { trackAction, type AnalyticsAction } from '@/utils/analytics';
 import { saveReturnUrl, isValidReturnUrl } from '@/utils/storefrontPasswordRedirect';
 import { refreshThemesCacheIfNeeded } from '@/utils/themesCache';
 import { captureOrganizationId } from '@/entrypoints/collaborator-access.content/presets';
+import { getItem } from '@/utils/storage';
 
 const UNINSTALL_SURVEY_URL = 'https://tally.so/r/zx79O8';
 
@@ -101,15 +102,18 @@ export default defineBackground(() => {
     }
   });
 
-  browser.runtime.onInstalled.addListener((details) => {
+  browser.runtime.onInstalled.addListener(async (details) => {
     // Prefetch themes cache on install and update
     refreshThemesCacheIfNeeded();
 
-    // Open changelog page when extension is updated
+    // Open changelog page when extension is updated, unless disabled in settings
     if (!import.meta.env.DEV && details.reason === 'update') {
-      browser.tabs.create({
-        url: browser.runtime.getURL('/options.html?page=changelog')
-      });
+      const settings = await getItem<AlfredSettings>('settings');
+      if (settings?.general?.openChangelogOnUpdate !== false) {
+        browser.tabs.create({
+          url: browser.runtime.getURL('/options.html?page=changelog')
+        });
+      }
     }
   });
 });

--- a/entrypoints/options/components/settings/GeneralSettings.svelte
+++ b/entrypoints/options/components/settings/GeneralSettings.svelte
@@ -5,7 +5,8 @@
 
   const settingsItems = [
     { key: 'analytics', label: 'Share anonymous usage analytics', details: 'When enabled, anonymous feature usage data (e.g. which actions are used) is sent to help improve Alfred. No identifiable data is ever collected.' },
-    { key: 'restoreRightClick', label: 'Restore right-click', details: 'Re-enables right-click context menu and text selection on Shopify sites that block them' }
+    { key: 'restoreRightClick', label: 'Restore right-click', details: 'Re-enables right-click context menu and text selection on Shopify sites that block them' },
+    { key: 'openChangelogOnUpdate', label: 'Open new updates on startup', details: 'Opens the changelog in a new tab whenever Alfred updates to a new version, so you can see what changed. Disable to update silently.' }
   ];
 </script>
 

--- a/entrypoints/options/components/settings/GeneralSettings.svelte
+++ b/entrypoints/options/components/settings/GeneralSettings.svelte
@@ -6,7 +6,7 @@
   const settingsItems = [
     { key: 'analytics', label: 'Share anonymous usage analytics', details: 'When enabled, anonymous feature usage data (e.g. which actions are used) is sent to help improve Alfred. No identifiable data is ever collected.' },
     { key: 'restoreRightClick', label: 'Restore right-click', details: 'Re-enables right-click context menu and text selection on Shopify sites that block them' },
-    { key: 'openChangelogOnUpdate', label: 'Open new updates on startup', details: 'Opens the changelog in a new tab whenever Alfred updates to a new version, so you can see what changed. Disable to update silently.' }
+    { key: 'openChangelogOnUpdate', label: 'Open changelog after updates', details: 'Opens the changelog in a new tab whenever Alfred updates to a new version, so you can see what changed. Disable to update silently.' }
   ];
 </script>
 

--- a/entrypoints/options/stores/settings.svelte.ts
+++ b/entrypoints/options/stores/settings.svelte.ts
@@ -4,7 +4,8 @@ import { Toast } from '@/utils/toast';
 const defaultSettings: AlfredSettings = {
   general: {
     analytics: true,
-    restoreRightClick: true
+    restoreRightClick: true,
+    openChangelogOnUpdate: true
   },
   themeCustomizer: {
     inspector: 'default',

--- a/global.d.ts
+++ b/global.d.ts
@@ -36,6 +36,7 @@ declare interface AlfredSettings {
   general?: {
     analytics?: boolean;
     restoreRightClick?: boolean;
+    openChangelogOnUpdate?: boolean;
   };
   themeCustomizer?: {
     inspector?: 'default' | 'disable' | 'restore';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.06.15",
+  "version": "2026.06.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     name: 'Alfred - Shopify Theme Detector',
     description:
       'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.06.15',
+    version: '2026.06.17',
     action: {
       default_title: 'Alfred'
     },


### PR DESCRIPTION
## What does this PR do?
Adds an "Open new updates on startup" toggle to General settings so users can stop the changelog tab from opening every time Alfred updates. The setting defaults to on, preserving current behavior for existing users.

## How to test
Open the extension options → General settings.
Confirm the new Open new updates on startup checkbox appears and is enabled by default.
Uncheck it.
Simulate an update (e.g. bump the version and reload the unpacked extension) → no changelog tab should open.
Re-enable it, simulate another update → the changelog tab opens as before.

## Checklist

- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] Tested in Chrome
- [x] No new permissions required (or explained why)
