### PR TITLE
v2026.06.20 feat(popup): add Schema tab for JSON-LD structured data

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,31 @@
 [
   {
+    "version": "2026.06.20",
+    "date": "2026-06-20",
+    "changes": [
+      {
+        "type": "heading",
+        "content": "Schema Analyzer"
+      },
+      {
+        "type": "paragraph",
+        "content": "A new Schema tab analyzes the JSON-LD structured data on your website — the markup Google reads for rich results — laid out as clean, readable tables."
+      },
+      {
+        "type": "image",
+        "content": "https://bucket.alfred.uptek.com/alfred-seo-schema.jpg",
+        "alt": "The new Schema tab showing structured data as readable tables"
+      },
+      {
+        "type": "list",
+        "content": [
+          "Entities bundled in a single @graph block are split out into separate, named types.",
+          "Copy any single type's JSON with one click, or copy and export everything at once."
+        ]
+      }
+    ]
+  },
+  {
     "version": "2026.06.17",
     "date": "2026-06-17",
     "changes": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026.06.20
+@ 2026-06-20
+
+### Schema Analyzer
+A new Schema tab analyzes the JSON-LD structured data on your website — the markup Google reads for rich results — laid out as clean, readable tables.
+
+![The new Schema tab showing structured data as readable tables](https://bucket.alfred.uptek.com/alfred-seo-schema.jpg)
+- Entities bundled in a single @graph block are split out into separate, named types.
+- Copy any single type's JSON with one click, or copy and export everything at once.
+
 ## 2026.06.17
 @ 2026-06-17
 A new General setting lets you stop the changelog from opening in a new tab every time Alfred updates. It stays on by default, so nothing changes unless you turn it off.

--- a/entrypoints/main.content.ts
+++ b/entrypoints/main.content.ts
@@ -273,6 +273,37 @@ export default defineContentScript({
       }
 
       /**
+       * Extracts every JSON-LD block (`<script type="application/ld+json">`) in
+       * DOM order. Each block's text is captured verbatim (capped) and parsed
+       * once only to record whether it is well-formed; the popup re-parses,
+       * validates, and pretty-prints from the raw text.
+       * @returns {RawSchemaBlock[]}
+       */
+      if (request.action === 'get_schema') {
+        const MAX_SCHEMA_INLINE = 50000; // cap raw JSON per block (~50KB)
+        const scripts = Array.from(
+          document.querySelectorAll<HTMLScriptElement>('script[type="application/ld+json" i]')
+        );
+        const blocks = scripts.map((el, i) => {
+          const raw = (el.textContent ?? '').slice(0, MAX_SCHEMA_INLINE);
+          let parseError: string | null = null;
+          try {
+            JSON.parse(raw);
+          } catch (err) {
+            parseError = (err as Error).message;
+          }
+          return {
+            index: i,
+            raw,
+            parseError,
+            placement: document.head?.contains(el) ? ('head' as const) : ('body' as const)
+          };
+        });
+        sendResponse(blocks);
+        return false;
+      }
+
+      /**
        * Extracts all anchor links from the page in DOM order. Each anchor is
        * stamped with its index so scroll_to_link can find it even if the DOM
        * mutates afterwards (lazy menus, carousels).

--- a/entrypoints/main.content.ts
+++ b/entrypoints/main.content.ts
@@ -274,9 +274,9 @@ export default defineContentScript({
 
       /**
        * Extracts every JSON-LD block (`<script type="application/ld+json">`) in
-       * DOM order. Each block's text is captured verbatim (capped) and parsed
-       * once only to record whether it is well-formed; the popup re-parses,
-       * validates, and pretty-prints from the raw text.
+       * DOM order. Each block's text is captured verbatim and parsed once to
+       * record whether it is well-formed; the popup re-parses and pretty-prints
+       * from the raw text.
        * @returns {RawSchemaBlock[]}
        */
       if (request.action === 'get_schema') {
@@ -289,9 +289,8 @@ export default defineContentScript({
           ldJsonEssence
         );
         const blocks = scripts.map((el, i) => {
-          // Capture the full block: truncating would make a large-but-valid
-          // schema (e.g. a Product with many variant offers) parse as malformed
-          // and ship a broken payload to Copy/Export.
+          // Full text, never capped: clipping a large valid schema makes it
+          // parse as malformed and corrupts Copy/Export.
           const raw = el.textContent ?? '';
           let parseError: string | null = null;
           try {

--- a/entrypoints/main.content.ts
+++ b/entrypoints/main.content.ts
@@ -281,8 +281,13 @@ export default defineContentScript({
        */
       if (request.action === 'get_schema') {
         const MAX_SCHEMA_INLINE = 50000; // cap raw JSON per block (~50KB)
-        const scripts = Array.from(
-          document.querySelectorAll<HTMLScriptElement>('script[type="application/ld+json" i]')
+        // Match on the MIME essence so a type with parameters
+        // (e.g. "application/ld+json; charset=utf-8") still counts. The
+        // substring selector narrows the candidates; the filter confirms.
+        const ldJsonEssence = (el: HTMLScriptElement) =>
+          (el.getAttribute('type') ?? '').split(';')[0]!.trim().toLowerCase() === 'application/ld+json';
+        const scripts = Array.from(document.querySelectorAll<HTMLScriptElement>('script[type*="ld+json" i]')).filter(
+          ldJsonEssence
         );
         const blocks = scripts.map((el, i) => {
           const raw = (el.textContent ?? '').slice(0, MAX_SCHEMA_INLINE);

--- a/entrypoints/main.content.ts
+++ b/entrypoints/main.content.ts
@@ -280,7 +280,6 @@ export default defineContentScript({
        * @returns {RawSchemaBlock[]}
        */
       if (request.action === 'get_schema') {
-        const MAX_SCHEMA_INLINE = 50000; // cap raw JSON per block (~50KB)
         // Match on the MIME essence so a type with parameters
         // (e.g. "application/ld+json; charset=utf-8") still counts. The
         // substring selector narrows the candidates; the filter confirms.
@@ -290,7 +289,10 @@ export default defineContentScript({
           ldJsonEssence
         );
         const blocks = scripts.map((el, i) => {
-          const raw = (el.textContent ?? '').slice(0, MAX_SCHEMA_INLINE);
+          // Capture the full block: truncating would make a large-but-valid
+          // schema (e.g. a Product with many variant offers) parse as malformed
+          // and ship a broken payload to Copy/Export.
+          const raw = el.textContent ?? '';
           let parseError: string | null = null;
           try {
             JSON.parse(raw);

--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getTheme, getHeadings, getLinks, getAssets, getImages } from './utils/utils';
+  import { getTheme, getHeadings, getLinks, getAssets, getImages, getSchema } from './utils/utils';
   import { analyzeHeadings } from './utils/headings';
   import { analyzeImages } from './utils/images';
   import { trackAction } from '@/utils/analytics';
@@ -8,12 +8,13 @@
   import Links from './Links.svelte';
   import Assets from './Assets.svelte';
   import Images from './Images.svelte';
+  import Schema from './Schema.svelte';
   import Settings from './Settings.svelte';
   import ReviewPrompt from './ReviewPrompt.svelte';
-  import type { StoreInfo, RawHeading, RawLink, RawAsset, RawImage } from './utils/types';
+  import type { StoreInfo, RawHeading, RawLink, RawAsset, RawImage, RawSchemaBlock } from './utils/types';
 
-  type TabId = 'theme' | 'headings' | 'links' | 'assets' | 'images' | 'settings';
-  // Future tabs: 'apps' | 'products' | 'overview' | 'hreflangs' | 'schema' | 'social' | 'robots' | 'sitemaps'
+  type TabId = 'theme' | 'headings' | 'links' | 'assets' | 'images' | 'schema' | 'settings';
+  // Future tabs: 'apps' | 'products' | 'overview' | 'hreflangs' | 'social' | 'robots' | 'sitemaps'
 
   interface Tab {
     id: TabId;
@@ -36,6 +37,7 @@
   let rawLinks = $state<RawLink[]>([]);
   let rawAssets = $state<RawAsset[]>([]);
   let rawImages = $state<RawImage[]>([]);
+  let rawSchema = $state<RawSchemaBlock[]>([]);
   let loading = $state(true);
 
   const headingIssues = $derived(analyzeHeadings(rawHeadings));
@@ -58,7 +60,7 @@
       ...(imageIssueCount > 0 ? { badge: { count: imageIssueCount, color: 'red' as const } } : {})
     },
     // { id: 'hreflangs', label: 'Hreflangs', icon: 'hreflangs' },
-    // { id: 'schema', label: 'Schema', icon: 'schema' },
+    { id: 'schema' as TabId, label: 'Schema', icon: 'schema' },
     // { id: 'social', label: 'Social', icon: 'social' },
     // { id: 'robots', label: 'Robots.txt', icon: 'robots' },
     // { id: 'sitemaps', label: 'Sitemaps', icon: 'sitemaps' },
@@ -66,12 +68,13 @@
 
   $effect(() => {
     const fetchData = async () => {
-      const [storeData, headingsData, linksData, assetsData, imagesData] = await Promise.all([
+      const [storeData, headingsData, linksData, assetsData, imagesData, schemaData] = await Promise.all([
         getTheme(),
         getHeadings(),
         getLinks(),
         getAssets(),
-        getImages()
+        getImages(),
+        getSchema()
       ]);
       trackAction('popup_open', { is_shopify: storeData?.isShopify ?? false });
       storeInfo = storeData;
@@ -79,6 +82,7 @@
       rawLinks = linksData;
       rawAssets = assetsData;
       rawImages = imagesData;
+      rawSchema = schemaData;
       if (!storeData?.isShopify) {
         activeTab = 'headings';
       }
@@ -101,6 +105,8 @@
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
   {:else if icon === 'images'}
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+  {:else if icon === 'schema'}
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg>
   <!-- Future tab icons (uncomment as tabs are enabled)
   {:else if icon === 'apps'}
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
@@ -110,8 +116,6 @@
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
   {:else if icon === 'hreflangs'}
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
-  {:else if icon === 'schema'}
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg>
   {:else if icon === 'social'}
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
   {:else if icon === 'robots'}
@@ -212,6 +216,8 @@
           <Assets assets={rawAssets} domain={storeInfo?.domain ?? null} />
         {:else if activeTab === 'images'}
           <Images images={rawImages} domain={storeInfo?.domain ?? null} />
+        {:else if activeTab === 'schema'}
+          <Schema schema={rawSchema} domain={storeInfo?.domain ?? null} />
         {:else if activeTab === 'settings'}
           <div class="content__pad">
             <Settings storeInfo={storeInfo ?? { isShopify: false, shopDomain: null, domain: null, page_url: null, theme: null }} />

--- a/entrypoints/popup/Schema.svelte
+++ b/entrypoints/popup/Schema.svelte
@@ -1,0 +1,333 @@
+<script lang="ts">
+  import type { RawSchemaBlock, SchemaEntity } from './utils/types';
+  import { analyzeSchema, schemaTypeName } from './utils/schema';
+  import SummaryBar from './SummaryBar.svelte';
+  import type { SummaryItem } from './SummaryBar.svelte';
+  import { trackAction } from '@/utils/analytics';
+  import { untrack, onDestroy } from 'svelte';
+
+  let { schema, domain }: { schema: RawSchemaBlock[]; domain: string | null } = $props();
+
+  const siteSlug = $derived(domain?.replace(/^www\./, '').replace(/[^a-z0-9]+/gi, '-').replace(/-+$/, '') ?? 'site');
+
+  const analysis = $derived(analyzeSchema(schema));
+
+  // Entity-level accordion: first entity open by default; explicit toggles override.
+  let overrides = $state<Map<number, boolean>>(new Map());
+  function isOpen(i: number): boolean {
+    return overrides.get(i) ?? i === 0;
+  }
+  function toggle(i: number) {
+    const next = new Map(overrides);
+    next.set(i, !isOpen(i));
+    overrides = next;
+  }
+
+  // Flattens a parsed node into table rows. Scalars are leaf rows; nested
+  // objects/arrays become a group header row followed by indented child rows;
+  // an array of plain scalars (e.g. sameAs) collapses into one multi-line cell.
+  type Row =
+    | { kind: 'leaf'; depth: number; label: string; value: string }
+    | { kind: 'list'; depth: number; label: string; items: string[] }
+    | { kind: 'group'; depth: number; label: string; meta: string };
+
+  const isObj = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null && !Array.isArray(v);
+  const isScalar = (v: unknown): boolean => v === null || (typeof v !== 'object');
+  const isUrl = (v: string): boolean => /^https?:\/\//i.test(v.trim());
+
+  function addRow(label: string, value: unknown, depth: number, rows: Row[]): void {
+    if (depth > 20) {
+      // Guard against pathological / self-referential nesting blowing the stack.
+      rows.push({ kind: 'leaf', depth, label, value: '[nested too deep]' });
+      return;
+    }
+    if (Array.isArray(value)) {
+      if (value.every(isScalar)) {
+        rows.push({ kind: 'list', depth, label, items: value.map((v) => (v === null ? 'null' : String(v))) });
+      } else {
+        rows.push({ kind: 'group', depth, label, meta: `${value.length} ${value.length === 1 ? 'item' : 'items'}` });
+        value.forEach((item, i) => addRow(String(i + 1), item, depth + 1, rows));
+      }
+    } else if (isObj(value)) {
+      const t = schemaTypeName(value);
+      rows.push({ kind: 'group', depth, label, meta: t === 'Unknown' ? 'object' : t });
+      for (const [k, v] of Object.entries(value)) {
+        if (k === '@context' || k === '@type') continue;
+        addRow(k.startsWith('@') ? k.slice(1) : k, v, depth + 1, rows);
+      }
+    } else {
+      rows.push({ kind: 'leaf', depth, label, value: value === null ? 'null' : String(value) });
+    }
+  }
+
+  function tableRows(data: Record<string, unknown>): Row[] {
+    const rows: Row[] = [];
+    for (const [k, v] of Object.entries(data)) {
+      if (k === '@context' || k === '@type') continue;
+      addRow(k.startsWith('@') ? k.slice(1) : k, v, 0, rows);
+    }
+    return rows;
+  }
+
+  let tracked = false;
+  $effect(() => {
+    const { entities, invalidBlocks } = analysis;
+    if (tracked || (entities.length === 0 && invalidBlocks.length === 0)) return;
+    tracked = true;
+    untrack(() => {
+      trackAction('schema_view', {
+        blocks: schema.length,
+        entities: entities.length,
+        invalid: invalidBlocks.length
+      });
+    });
+  });
+
+  const summaryItems = $derived.by(() => {
+    const n = analysis.entities.length;
+    const items: SummaryItem[] = [{ text: `${n} ${n === 1 ? 'type' : 'types'}` }];
+    if (analysis.invalidBlocks.length > 0) {
+      items.push({ text: `${analysis.invalidBlocks.length} invalid`, tone: 'err', title: 'Blocks that failed to parse as JSON' });
+    }
+    return items;
+  });
+
+  let copied = $state(false);
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+  function downloadFile(content: string, filename: string, mime: string) {
+    const blob = new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+  async function copyAll() {
+    const text = schema.map((b) => b.raw).join('\n\n');
+    try {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+      if (copyTimer) clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => { copied = false; }, 1500);
+      trackAction('schema_copy', { scope: 'all', blocks: schema.length });
+    } catch {
+      // ignore clipboard errors
+    }
+  }
+  function exportJson() {
+    const data = analysis.entities.map((e) => e.data);
+    downloadFile(JSON.stringify(data, null, 2), `alfred-schema-${siteSlug}.json`, 'application/json');
+    trackAction('schema_export', { format: 'json', entities: analysis.entities.length });
+  }
+
+  // Per-entity copy: grabs just this type's JSON (handy for pasting one entity
+  // into Google's Rich Results Test, even when several share a @graph block).
+  let copiedIndex = $state<number | null>(null);
+  let entityTimer: ReturnType<typeof setTimeout> | null = null;
+  async function copyEntity(i: number, entity: SchemaEntity) {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(entity.data, null, 2));
+      copiedIndex = i;
+      if (entityTimer) clearTimeout(entityTimer);
+      entityTimer = setTimeout(() => { copiedIndex = null; }, 1500);
+      trackAction('schema_copy', { scope: 'entity', type: entity.type });
+    } catch {
+      // ignore clipboard errors
+    }
+  }
+
+  onDestroy(() => {
+    if (copyTimer) clearTimeout(copyTimer);
+    if (entityTimer) clearTimeout(entityTimer);
+  });
+</script>
+
+{#if schema.length === 0}
+  <div class="empty-state">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="empty-state__icon"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg>
+    <p>No structured data found on this page</p>
+  </div>
+{:else}
+  <div class="schema-tab">
+    <div class="toolbar">
+      <span class="toolbar__hint">JSON-LD structured data</span>
+      <div class="toolbar__actions">
+        <button class="toolbar-btn" onclick={copyAll} title="Copy all JSON-LD">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+        <button class="toolbar-btn" onclick={exportJson} title="Download JSON-LD">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          Export
+        </button>
+      </div>
+    </div>
+
+    <div class="list">
+      {#each analysis.entities as entity, i (i)}
+        {@const open = isOpen(i)}
+        <div class="entity">
+          <div class="entity__head">
+            <button class="entity__header" class:entity__header--open={open} aria-expanded={open} onclick={() => toggle(i)}>
+              <svg class="entity__chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>
+              <span class="entity__num">{i + 1}</span>
+              <span class="entity__type">{entity.type}</span>
+            </button>
+            <button
+              class="entity__copy"
+              class:entity__copy--done={copiedIndex === i}
+              title="Copy this type's JSON"
+              aria-label="Copy {entity.type} JSON"
+              onclick={() => copyEntity(i, entity)}
+            >
+              {#if copiedIndex === i}
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+              {:else}
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+              {/if}
+            </button>
+          </div>
+          {#if open}
+            <div class="entity__body">
+              <table class="kv">
+                <tbody>
+                  {#each tableRows(entity.data) as row, idx (idx)}
+                    <tr class="kv__row kv__row--{row.kind}">
+                      <td class="kv__key" style="padding-left:{row.depth * 16}px">{row.label}</td>
+                      <td class="kv__val">
+                        {#if row.kind === 'group'}
+                          <span class="kv__meta">{row.meta}</span>
+                        {:else if row.kind === 'list'}
+                          {#each row.items as item, j (j)}
+                            <div class="kv__line">
+                              {#if isUrl(item)}<a class="kv__url" href={item} target="_blank" rel="noopener noreferrer">{item}</a>{:else if item === ''}<span class="kv__empty">empty</span>{:else}{item}{/if}
+                            </div>
+                          {/each}
+                        {:else if isUrl(row.value)}
+                          <a class="kv__url" href={row.value} target="_blank" rel="noopener noreferrer">{row.value}</a>
+                        {:else if row.value === ''}
+                          <span class="kv__empty">empty</span>
+                        {:else}
+                          {row.value}
+                        {/if}
+                      </td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          {/if}
+        </div>
+      {/each}
+
+      {#each analysis.invalidBlocks as bad (bad.blockIndex)}
+        <div class="entity entity--invalid">
+          <div class="entity__header entity__header--static">
+            <span class="entity__type">Block {bad.blockIndex + 1}</span>
+            <span class="badge badge--red" title="This block is not valid JSON">invalid JSON</span>
+          </div>
+          <div class="entity__body">
+            <div class="issues">
+              <div class="issue issue--error">
+                <span class="issue__tag">Parse</span>
+                <span class="issue__msg issue__msg--mono">{bad.error}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <SummaryBar items={summaryItems} />
+  </div>
+{/if}
+
+<style>
+  .schema-tab { display: flex; flex-direction: column; height: 100%; animation: fadeUp 0.4s ease both; }
+
+  /* Empty state */
+  .empty-state { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; gap: 8px; color: var(--text-muted); }
+  .empty-state__icon { width: 28px; height: 28px; opacity: 0.3; stroke-width: 1.7; }
+  .empty-state p { font-size: 13px; margin: 0; }
+
+  /* Toolbar */
+  .toolbar { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 10px 20px; border-bottom: 1px solid var(--border); flex-shrink: 0; }
+  .toolbar__hint { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-label); }
+  .toolbar__actions { display: flex; align-items: center; gap: 6px; }
+  .toolbar-btn { display: flex; align-items: center; gap: 4px; padding: 0 8px; height: 28px; border-radius: 6px; border: 1px solid var(--border-strong); background: var(--bg); font-family: inherit; font-size: 11px; font-weight: 600; color: var(--text-muted); cursor: pointer; transition: all 0.12s; }
+  .toolbar-btn:hover { border-color: var(--border-hover); color: var(--text-secondary); }
+  .toolbar-btn svg { width: 13px; height: 13px; stroke-width: 1.8; flex-shrink: 0; }
+
+  /* List */
+  .list { flex: 1; overflow-y: auto; overflow-x: hidden; padding: 6px 20px 12px; }
+  .list::-webkit-scrollbar { width: 3px; }
+  .list::-webkit-scrollbar-thumb { background: var(--scrollbar); border-radius: 3px; }
+
+  /* Entity accordion */
+  .entity { border-bottom: 1px solid var(--border-muted); }
+  .entity:last-child { border-bottom: none; }
+  .entity__head { display: flex; align-items: center; }
+  .entity__header { flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 9px; width: 100%; padding: 13px 0; background: none; border: none; font-family: inherit; text-align: left; cursor: pointer; color: var(--text); }
+  .entity__header--static { cursor: default; }
+
+  /* Per-type copy: a quiet ghost button, always visible, darkening on hover. */
+  .entity__copy { display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; width: 28px; height: 28px; margin-left: 8px; border: none; border-radius: 6px; background: none; color: var(--text-faint); cursor: pointer; transition: color 0.12s, background 0.12s; }
+  .entity__copy:hover { color: var(--text-secondary); background: var(--bg-hover); }
+  .entity__copy svg { width: 14px; height: 14px; stroke-width: 1.8; }
+  .entity__copy--done, .entity__copy--done:hover { color: var(--success); }
+  .entity__chevron { width: 14px; height: 14px; flex-shrink: 0; stroke-width: 2.2; color: var(--text-muted); transition: transform 0.15s; }
+  .entity__header--open .entity__chevron { transform: rotate(90deg); }
+  .entity__num { font-size: 12px; font-weight: 600; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+  .entity__type { font-size: 14px; font-weight: 650; letter-spacing: -0.01em; color: var(--text); }
+  .entity__header .badge { margin-left: auto; }
+
+  /* Key/value table — flattened JSON-LD, one property per row. Hairline rows,
+     muted keys, dark values; nested props indent under a group header. */
+  .entity__body { padding: 0 0 12px; }
+  .kv { width: 100%; border-collapse: collapse; table-layout: auto; }
+  .kv__row { border-bottom: 1px solid var(--border-subtle); }
+  .kv__row:last-child { border-bottom: none; }
+  .kv__key {
+    width: 1%;
+    white-space: nowrap;
+    vertical-align: top;
+    padding: 7px 16px 7px 0;
+    font-size: 12.5px;
+    color: var(--text-muted);
+  }
+  .kv__val {
+    vertical-align: top;
+    padding: 7px 0;
+    font-size: 12.5px;
+    color: var(--text);
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+  .kv__row--group .kv__key { color: var(--text); font-weight: 600; }
+  .kv__meta { color: var(--text-faint); font-size: 11.5px; }
+  .kv__line { padding: 1px 0; }
+  .kv__url { color: var(--accent); text-decoration: none; }
+  .kv__url:hover { text-decoration: underline; text-underline-offset: 2px; }
+  .kv__empty { color: var(--text-disabled); font-style: italic; }
+
+  /* Invalid-JSON callout — a tinted error strip for blocks that failed to parse. */
+  .issues { margin: 10px -20px 0; display: flex; flex-direction: column; }
+  .issue { display: flex; align-items: baseline; gap: 9px; padding: 7px 20px; font-size: 12.5px; border-top: 1px solid var(--border-subtle); }
+  .issue--error { background: var(--error-bg); }
+  .issue__tag { flex-shrink: 0; font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; padding-top: 1px; }
+  .issue--error .issue__tag { color: var(--error-strong); }
+  .issue__msg { color: var(--text-secondary); }
+  .issue__msg--mono { font-family: 'SF Mono', ui-monospace, monospace; font-size: 11.5px; color: var(--error-strong); }
+
+  .entity--invalid .entity__type { color: var(--error-strong); }
+
+  /* Badge — only the invalid-JSON marker remains. */
+  .badge { display: inline-flex; align-items: center; flex-shrink: 0; font-size: 10.5px; font-weight: 600; padding: 1px 8px; border-radius: 20px; white-space: nowrap; }
+  .badge--red { background: var(--error-bg); color: var(--error-strong); }
+
+  @keyframes fadeUp {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+</style>

--- a/entrypoints/popup/Schema.svelte
+++ b/entrypoints/popup/Schema.svelte
@@ -12,7 +12,6 @@
 
   const analysis = $derived(analyzeSchema(schema));
 
-  // Entity-level accordion: first entity open by default; explicit toggles override.
   let overrides = $state<Map<number, boolean>>(new Map());
   function isOpen(i: number): boolean {
     return overrides.get(i) ?? i === 0;
@@ -23,9 +22,6 @@
     overrides = next;
   }
 
-  // Flattens a parsed node into table rows. Scalars are leaf rows; nested
-  // objects/arrays become a group header row followed by indented child rows;
-  // an array of plain scalars (e.g. sameAs) collapses into one multi-line cell.
   type Row =
     | { kind: 'leaf'; depth: number; label: string; value: string }
     | { kind: 'list'; depth: number; label: string; items: string[] }
@@ -121,8 +117,6 @@
     trackAction('schema_export', { format: 'json', entities: analysis.entities.length });
   }
 
-  // Per-entity copy: grabs just this type's JSON (handy for pasting one entity
-  // into Google's Rich Results Test, even when several share a @graph block).
   let copiedIndex = $state<number | null>(null);
   let entityTimer: ReturnType<typeof setTimeout> | null = null;
   async function copyEntity(i: number, entity: SchemaEntity) {
@@ -271,7 +265,7 @@
   .entity__header { flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 9px; width: 100%; padding: 13px 0; background: none; border: none; font-family: inherit; text-align: left; cursor: pointer; color: var(--text); }
   .entity__header--static { cursor: default; }
 
-  /* Per-type copy: a quiet ghost button, always visible, darkening on hover. */
+  /* Per-type copy button */
   .entity__copy { display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; width: 28px; height: 28px; margin-left: 8px; border: none; border-radius: 6px; background: none; color: var(--text-faint); cursor: pointer; transition: color 0.12s, background 0.12s; }
   .entity__copy:hover { color: var(--text-secondary); background: var(--bg-hover); }
   .entity__copy svg { width: 14px; height: 14px; stroke-width: 1.8; }
@@ -282,8 +276,7 @@
   .entity__type { font-size: 14px; font-weight: 650; letter-spacing: -0.01em; color: var(--text); }
   .entity__header .badge { margin-left: auto; }
 
-  /* Key/value table — flattened JSON-LD, one property per row. Hairline rows,
-     muted keys, dark values; nested props indent under a group header. */
+  /* Key/value table */
   .entity__body { padding: 0 0 12px; }
   .kv { width: 100%; border-collapse: collapse; table-layout: auto; }
   .kv__row { border-bottom: 1px solid var(--border-subtle); }
@@ -311,7 +304,7 @@
   .kv__url:hover { text-decoration: underline; text-underline-offset: 2px; }
   .kv__empty { color: var(--text-disabled); font-style: italic; }
 
-  /* Invalid-JSON callout — a tinted error strip for blocks that failed to parse. */
+  /* Invalid-JSON callout */
   .issues { margin: 10px -20px 0; display: flex; flex-direction: column; }
   .issue { display: flex; align-items: baseline; gap: 9px; padding: 7px 20px; font-size: 12.5px; border-top: 1px solid var(--border-subtle); }
   .issue--error { background: var(--error-bg); }
@@ -322,7 +315,7 @@
 
   .entity--invalid .entity__type { color: var(--error-strong); }
 
-  /* Badge — only the invalid-JSON marker remains. */
+  /* Badge */
   .badge { display: inline-flex; align-items: center; flex-shrink: 0; font-size: 10.5px; font-weight: 600; padding: 1px 8px; border-radius: 20px; white-space: nowrap; }
   .badge--red { background: var(--error-bg); color: var(--error-strong); }
 

--- a/entrypoints/popup/tests/analytics-actions-sync.test.ts
+++ b/entrypoints/popup/tests/analytics-actions-sync.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Repo root, resolved from this test file's location (entrypoints/popup/tests).
+const ROOT = join(import.meta.dir, '..', '..', '..');
+
+/** Pull every single-quoted string literal out of a source slice. */
+function literals(source: string, startMarker: string, endMarker: string): string[] {
+  const start = source.indexOf(startMarker);
+  if (start === -1) throw new Error(`marker not found: ${startMarker}`);
+  const end = source.indexOf(endMarker, start);
+  if (end === -1) throw new Error(`end marker not found: ${endMarker}`);
+  const slice = source.slice(start, end);
+  return [...slice.matchAll(/'([a-z_]+)'/g)].map((m) => m[1]!).sort();
+}
+
+// The client's AnalyticsAction union (utils/analytics.ts) is the set of events
+// trackAction() can send. The Supabase edge function (supabase/functions/track)
+// only INSERTS events whose action is in VALID_ACTIONS — anything else is
+// acknowledged but silently dropped. The two lists must stay identical, or new
+// events vanish from remote analytics with no error. This test is the canary.
+describe('analytics action allowlist parity', () => {
+  it('client AnalyticsAction union matches the server VALID_ACTIONS allowlist', () => {
+    const client = literals(readFileSync(join(ROOT, 'utils/analytics.ts'), 'utf8'), 'export type AnalyticsAction', ';');
+    const server = literals(
+      readFileSync(join(ROOT, 'supabase/functions/track/index.ts'), 'utf8'),
+      'const VALID_ACTIONS',
+      '];'
+    );
+
+    const missingOnServer = client.filter((a) => !server.includes(a));
+    const orphanOnServer = server.filter((a) => !client.includes(a));
+
+    expect({ missingOnServer, orphanOnServer }).toEqual({ missingOnServer: [], orphanOnServer: [] });
+  });
+});

--- a/entrypoints/popup/tests/schema.test.ts
+++ b/entrypoints/popup/tests/schema.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test';
+import { analyzeSchema, schemaTypeName } from '../utils/schema';
+import type { RawSchemaBlock } from '../utils/types';
+
+function block(value: unknown, index = 0, placement: 'head' | 'body' = 'head'): RawSchemaBlock {
+  return { index, raw: JSON.stringify(value), parseError: null, placement };
+}
+
+// A Product as Shopify themes emit it (single-variant form).
+const product = {
+  '@context': 'https://schema.org/',
+  '@type': 'Product',
+  name: 'Classic Tee',
+  image: ['https://cdn.example.com/tee.jpg'],
+  offers: {
+    '@type': 'Offer',
+    price: 19.99,
+    priceCurrency: 'USD',
+    availability: 'https://schema.org/InStock'
+  }
+};
+
+describe('analyzeSchema — extraction & flattening', () => {
+  it('returns nothing for no blocks', () => {
+    expect(analyzeSchema([])).toEqual({ entities: [], invalidBlocks: [] });
+  });
+
+  it('lifts each top-level block into its own entity', () => {
+    const org = { '@context': 'http://schema.org', '@type': 'Organization', name: 'Acme', url: 'https://acme.com' };
+    const site = { '@type': 'WebSite', name: 'Acme', url: 'https://acme.com' };
+    const { entities } = analyzeSchema([block(org, 0), block(site, 1)]);
+    expect(entities.map((e) => e.type)).toEqual(['Organization', 'WebSite']);
+    expect(entities.map((e) => e.blockIndex)).toEqual([0, 1]);
+  });
+
+  it('flattens a @graph into separate entities sharing the block index', () => {
+    const graph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        { '@type': 'Organization', name: 'Acme', url: 'https://acme.com' },
+        { '@type': 'WebSite', name: 'Acme', url: 'https://acme.com' }
+      ]
+    };
+    const { entities } = analyzeSchema([block(graph, 3)]);
+    expect(entities.map((e) => e.type)).toEqual(['Organization', 'WebSite']);
+    expect(entities.every((e) => e.blockIndex === 3)).toBe(true);
+  });
+
+  it('flattens a top-level JSON array into separate entities', () => {
+    const arr = [{ '@type': 'Organization', name: 'Acme', url: 'https://acme.com' }, product];
+    const { entities } = analyzeSchema([block(arr)]);
+    expect(entities.map((e) => e.type)).toEqual(['Organization', 'Product']);
+  });
+
+  it('keeps the parsed node available for the code-block view', () => {
+    const { entities } = analyzeSchema([block(product)]);
+    expect(entities[0]!.data.name).toBe('Classic Tee');
+  });
+
+  it('records malformed blocks separately instead of throwing', () => {
+    const bad: RawSchemaBlock = {
+      index: 2,
+      raw: '{ "@type": "Product", }',
+      parseError: 'Unexpected token }',
+      placement: 'body'
+    };
+    const { entities, invalidBlocks } = analyzeSchema([bad]);
+    expect(entities).toEqual([]);
+    expect(invalidBlocks).toEqual([{ blockIndex: 2, error: 'Unexpected token }' }]);
+  });
+
+  it('re-parses raw even when parseError was not pre-set, catching the error', () => {
+    const bad: RawSchemaBlock = { index: 0, raw: 'not json at all', parseError: null, placement: 'head' };
+    const { entities, invalidBlocks } = analyzeSchema([bad]);
+    expect(entities).toEqual([]);
+    expect(invalidBlocks).toHaveLength(1);
+    expect(invalidBlocks[0]!.blockIndex).toBe(0);
+  });
+});
+
+describe('schemaTypeName — @type normalization', () => {
+  it('reads a plain string type', () => {
+    expect(schemaTypeName({ '@type': 'Product' })).toBe('Product');
+  });
+  it('strips a full schema.org URL to its local name', () => {
+    expect(schemaTypeName({ '@type': 'http://schema.org/Product' })).toBe('Product');
+  });
+  it('uses the first member of a @type array', () => {
+    expect(schemaTypeName({ '@type': ['WebPage', 'FAQPage'] })).toBe('WebPage');
+  });
+  it('returns Unknown when @type is absent', () => {
+    expect(schemaTypeName({ name: 'x' })).toBe('Unknown');
+  });
+});

--- a/entrypoints/popup/tests/schema.test.ts
+++ b/entrypoints/popup/tests/schema.test.ts
@@ -67,6 +67,13 @@ describe('analyzeSchema — extraction & flattening', () => {
     expect(entities.map((e) => e.type)).toEqual(['Organization', 'Product']);
   });
 
+  it('expands a @graph whose value is a single node object (not an array)', () => {
+    const graph = { '@context': 'https://schema.org', '@graph': { '@type': 'Product', name: 'Solo' } };
+    const { entities } = analyzeSchema([block(graph)]);
+    expect(entities.map((e) => e.type)).toEqual(['Product']);
+    expect(entities[0]!.data['@context']).toBe('https://schema.org');
+  });
+
   it('expands a @graph wrapper nested inside a top-level array', () => {
     const arr = [
       {

--- a/entrypoints/popup/tests/schema.test.ts
+++ b/entrypoints/popup/tests/schema.test.ts
@@ -46,6 +46,21 @@ describe('analyzeSchema — extraction & flattening', () => {
     expect(entities.every((e) => e.blockIndex === 3)).toBe(true);
   });
 
+  it('copies the wrapper @context onto each @graph member that lacks one (so a single entity is valid standalone JSON-LD)', () => {
+    const graph = {
+      '@context': 'https://schema.org',
+      '@graph': [
+        { '@type': 'Organization', name: 'Acme' },
+        { '@context': 'http://schema.org', '@type': 'WebSite', name: 'Acme' }
+      ]
+    };
+    const { entities } = analyzeSchema([block(graph)]);
+    // member without its own @context inherits the wrapper's
+    expect(entities[0]!.data['@context']).toBe('https://schema.org');
+    // member that declares its own @context keeps it untouched
+    expect(entities[1]!.data['@context']).toBe('http://schema.org');
+  });
+
   it('flattens a top-level JSON array into separate entities', () => {
     const arr = [{ '@type': 'Organization', name: 'Acme', url: 'https://acme.com' }, product];
     const { entities } = analyzeSchema([block(arr)]);

--- a/entrypoints/popup/tests/schema.test.ts
+++ b/entrypoints/popup/tests/schema.test.ts
@@ -67,6 +67,21 @@ describe('analyzeSchema — extraction & flattening', () => {
     expect(entities.map((e) => e.type)).toEqual(['Organization', 'Product']);
   });
 
+  it('expands a @graph wrapper nested inside a top-level array', () => {
+    const arr = [
+      {
+        '@context': 'https://schema.org',
+        '@graph': [
+          { '@type': 'Organization', name: 'Acme' },
+          { '@type': 'WebSite', name: 'Acme' }
+        ]
+      }
+    ];
+    const { entities } = analyzeSchema([block(arr)]);
+    expect(entities.map((e) => e.type)).toEqual(['Organization', 'WebSite']);
+    expect(entities[0]!.data['@context']).toBe('https://schema.org');
+  });
+
   it('keeps the parsed node available for the code-block view', () => {
     const { entities } = analyzeSchema([block(product)]);
     expect(entities[0]!.data.name).toBe('Classic Tee');

--- a/entrypoints/popup/utils/schema.ts
+++ b/entrypoints/popup/utils/schema.ts
@@ -29,24 +29,31 @@ function isObject(v: unknown): v is Record<string, unknown> {
 }
 
 /**
- * Collects the root nodes from one parsed block (object, array, or @graph).
- * When splitting a @graph, the wrapper's @context is copied onto each member
- * that lacks its own, so a single entity stays valid standalone JSON-LD when
- * copied or exported (validators reject a node with no @context).
+ * Roots from a single node: a @graph wrapper expands to its members, anything
+ * else is its own root. Members inherit the wrapper @context so each stays valid
+ * standalone JSON-LD when copied or exported (validators reject a node with no
+ * @context).
+ */
+function rootsFromNode(node: Record<string, unknown>): Record<string, unknown>[] {
+  if (!Array.isArray(node['@graph'])) return [node];
+  const context = node['@context'];
+  return node['@graph']
+    .filter(isObject)
+    .map((member) =>
+      context === undefined || member['@context'] !== undefined
+        ? member
+        : Object.assign({ '@context': context }, member)
+    );
+}
+
+/**
+ * Collects the root nodes from one parsed block. A block may be a single node, a
+ * @graph wrapper, or a top-level array of either, so array elements run through
+ * the same wrapper expansion.
  */
 function rootsOf(parsed: unknown): Record<string, unknown>[] {
-  if (Array.isArray(parsed)) return parsed.filter(isObject);
-  if (isObject(parsed)) {
-    if (Array.isArray(parsed['@graph'])) {
-      const context = parsed['@context'];
-      return parsed['@graph'].filter(isObject).map((node) => {
-        if (context === undefined || node['@context'] !== undefined) return node;
-        // Fresh object per member; @context first so copied JSON-LD reads naturally.
-        return Object.assign({ '@context': context }, node);
-      });
-    }
-    return [parsed];
-  }
+  if (Array.isArray(parsed)) return parsed.filter(isObject).flatMap(rootsFromNode);
+  if (isObject(parsed)) return rootsFromNode(parsed);
   return [];
 }
 

--- a/entrypoints/popup/utils/schema.ts
+++ b/entrypoints/popup/utils/schema.ts
@@ -28,11 +28,23 @@ function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-/** Collects the root nodes from one parsed block (object, array, or @graph). */
+/**
+ * Collects the root nodes from one parsed block (object, array, or @graph).
+ * When splitting a @graph, the wrapper's @context is copied onto each member
+ * that lacks its own, so a single entity stays valid standalone JSON-LD when
+ * copied or exported (validators reject a node with no @context).
+ */
 function rootsOf(parsed: unknown): Record<string, unknown>[] {
   if (Array.isArray(parsed)) return parsed.filter(isObject);
   if (isObject(parsed)) {
-    if (Array.isArray(parsed['@graph'])) return parsed['@graph'].filter(isObject);
+    if (Array.isArray(parsed['@graph'])) {
+      const context = parsed['@context'];
+      return parsed['@graph'].filter(isObject).map((node) => {
+        if (context === undefined || node['@context'] !== undefined) return node;
+        // Fresh object per member; @context first so copied JSON-LD reads naturally.
+        return Object.assign({ '@context': context }, node);
+      });
+    }
     return [parsed];
   }
   return [];

--- a/entrypoints/popup/utils/schema.ts
+++ b/entrypoints/popup/utils/schema.ts
@@ -1,0 +1,70 @@
+import type { RawSchemaBlock, SchemaAnalysis, SchemaEntity } from './types';
+
+/** Strip a schema.org URL/prefix to its bare type name ('.../Product' → 'Product'). */
+function localName(type: string): string {
+  const slash = type.lastIndexOf('/');
+  const hash = type.lastIndexOf('#');
+  const cut = Math.max(slash, hash);
+  return cut >= 0 ? type.slice(cut + 1) : type;
+}
+
+/**
+ * Resolves a node's @type to a single display name. Handles string and array
+ * forms and full-URL types; for arrays, uses the first member.
+ * @param node - A parsed structured-data node.
+ * @returns {string} The local type name, or 'Unknown' when @type is absent.
+ */
+export function schemaTypeName(node: Record<string, unknown>): string {
+  const raw = node['@type'];
+  if (typeof raw === 'string') return localName(raw);
+  if (Array.isArray(raw)) {
+    const names = raw.filter((t): t is string => typeof t === 'string').map(localName);
+    return names[0] ?? 'Unknown';
+  }
+  return 'Unknown';
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Collects the root nodes from one parsed block (object, array, or @graph). */
+function rootsOf(parsed: unknown): Record<string, unknown>[] {
+  if (Array.isArray(parsed)) return parsed.filter(isObject);
+  if (isObject(parsed)) {
+    if (Array.isArray(parsed['@graph'])) return parsed['@graph'].filter(isObject);
+    return [parsed];
+  }
+  return [];
+}
+
+/**
+ * Parses the page's JSON-LD blocks into a flat list of entities.
+ *
+ * Each block is re-parsed from its raw text (cheap, and keeps the content-script
+ * payload to plain strings). Malformed blocks are reported separately rather
+ * than thrown. Well-formed blocks are flattened — top-level object, top-level
+ * array, or @graph members each become an entity.
+ *
+ * @param {RawSchemaBlock[]} blocks - JSON-LD blocks in DOM order.
+ * @returns {SchemaAnalysis} Entities plus any malformed blocks.
+ */
+export function analyzeSchema(blocks: RawSchemaBlock[]): SchemaAnalysis {
+  const entities: SchemaEntity[] = [];
+  const invalidBlocks: SchemaAnalysis['invalidBlocks'] = [];
+
+  for (const block of blocks) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(block.raw);
+    } catch (err) {
+      invalidBlocks.push({ blockIndex: block.index, error: block.parseError ?? (err as Error).message });
+      continue;
+    }
+    for (const node of rootsOf(parsed)) {
+      entities.push({ type: schemaTypeName(node), blockIndex: block.index, data: node });
+    }
+  }
+
+  return { entities, invalidBlocks };
+}

--- a/entrypoints/popup/utils/schema.ts
+++ b/entrypoints/popup/utils/schema.ts
@@ -35,9 +35,12 @@ function isObject(v: unknown): v is Record<string, unknown> {
  * @context).
  */
 function rootsFromNode(node: Record<string, unknown>): Record<string, unknown>[] {
-  if (!Array.isArray(node['@graph'])) return [node];
+  const graph = node['@graph'];
+  // @graph may be a node object or an array of node objects (JSON-LD 1.1).
+  const members = Array.isArray(graph) ? graph : isObject(graph) ? [graph] : null;
+  if (!members) return [node];
   const context = node['@context'];
-  return node['@graph']
+  return members
     .filter(isObject)
     .map((member) =>
       context === undefined || member['@context'] !== undefined

--- a/entrypoints/popup/utils/types.ts
+++ b/entrypoints/popup/utils/types.ts
@@ -55,6 +55,29 @@ export interface RawAsset {
   renderBlocking: boolean; // blocks first render (head, synchronous)
 }
 
+// One <script type="application/ld+json"> block, captured verbatim. The content
+// script attempts JSON.parse only to record whether it is well-formed; the raw
+// text is always sent so the popup can re-parse, pretty-print, and copy it.
+export interface RawSchemaBlock {
+  index: number; // position among ld+json scripts in DOM order (stable key)
+  raw: string; // original JSON text, capped (MAX_SCHEMA_INLINE)
+  parseError: string | null; // JSON.parse message; non-null => malformed block
+  placement: 'head' | 'body';
+}
+
+// One structured-data node lifted from a block (top-level, array element, or
+// @graph member), carrying its parsed data for the code-block view.
+export interface SchemaEntity {
+  type: string; // '@type' localName, e.g. 'Product'; 'Unknown' when absent
+  blockIndex: number; // which RawSchemaBlock it came from
+  data: Record<string, unknown>; // the parsed node, pretty-printed as JSON
+}
+
+export interface SchemaAnalysis {
+  entities: SchemaEntity[];
+  invalidBlocks: { blockIndex: number; error: string }[]; // malformed JSON blocks
+}
+
 export type HeadingIssueType = 'missing-h1' | 'multiple-h1' | 'skipped-level' | 'empty' | 'h1-not-first';
 
 export interface HeadingIssue {

--- a/entrypoints/popup/utils/types.ts
+++ b/entrypoints/popup/utils/types.ts
@@ -60,7 +60,7 @@ export interface RawAsset {
 // text is always sent so the popup can re-parse, pretty-print, and copy it.
 export interface RawSchemaBlock {
   index: number; // position among ld+json scripts in DOM order (stable key)
-  raw: string; // original JSON text, captured in full (not truncated)
+  raw: string;
   parseError: string | null; // JSON.parse message; non-null => malformed block
   placement: 'head' | 'body';
 }

--- a/entrypoints/popup/utils/types.ts
+++ b/entrypoints/popup/utils/types.ts
@@ -60,7 +60,7 @@ export interface RawAsset {
 // text is always sent so the popup can re-parse, pretty-print, and copy it.
 export interface RawSchemaBlock {
   index: number; // position among ld+json scripts in DOM order (stable key)
-  raw: string; // original JSON text, capped (MAX_SCHEMA_INLINE)
+  raw: string; // original JSON text, captured in full (not truncated)
   parseError: string | null; // JSON.parse message; non-null => malformed block
   placement: 'head' | 'body';
 }

--- a/entrypoints/popup/utils/utils.ts
+++ b/entrypoints/popup/utils/utils.ts
@@ -1,4 +1,4 @@
-import type { StoreInfo, Theme, RawHeading, RawLink, RawAsset, RawImage } from './types';
+import type { StoreInfo, Theme, RawHeading, RawLink, RawAsset, RawImage, RawSchemaBlock } from './types';
 import { lookupThemeStoreEntry } from './themeStoreLookup';
 
 /**
@@ -89,6 +89,23 @@ export const getAssets = async (): Promise<RawAsset[]> => {
     const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
     if (tab?.id) {
       const response = await browser.tabs.sendMessage(tab.id, { action: 'get_assets' });
+      return Array.isArray(response) ? response : [];
+    }
+    return [];
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Extracts all JSON-LD structured-data blocks from the active tab via content script.
+ * @returns {Promise<RawSchemaBlock[]>} Blocks in DOM order, or empty array on failure.
+ */
+export const getSchema = async (): Promise<RawSchemaBlock[]> => {
+  try {
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    if (tab?.id) {
+      const response = await browser.tabs.sendMessage(tab.id, { action: 'get_schema' });
       return Array.isArray(response) ? response : [];
     }
     return [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.06.17",
+  "version": "2026.06.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/supabase/functions/track/index.ts
+++ b/supabase/functions/track/index.ts
@@ -62,13 +62,25 @@ const VALID_ACTIONS = [
   'links_export',
   'links_copy',
   'links_sort',
+  'links_toggle_hidden',
   'assets_view',
   'assets_filter',
   'assets_export',
   'assets_copy',
   'assets_view_source',
   'assets_expand_inline',
-  'assets_sort'
+  'assets_sort',
+  'images_view',
+  'images_filter',
+  'images_highlight',
+  'images_scroll_to',
+  'images_export',
+  'images_copy',
+  'images_sort',
+  'images_open',
+  'schema_view',
+  'schema_copy',
+  'schema_export'
 ];
 
 serve(async (req) => {

--- a/test-pages/schema/graph-nested.html
+++ b/test-pages/schema/graph-nested.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Single @graph block holding several entities</title>
+    <style>
+      body {
+        font:
+          15px/1.7 system-ui,
+          sans-serif;
+        margin: 0;
+        background: #fff;
+        color: #222;
+      }
+      .expected {
+        background: #eef4ff;
+        border: 1px solid #c7d8f7;
+        border-radius: 8px;
+        margin: 16px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+      .expected .t {
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .expected ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      main {
+        max-width: 680px;
+        margin: 24px auto 48px;
+        padding: 0 16px;
+      }
+      .back {
+        display: inline-block;
+        margin: 0 16px 24px;
+        font-size: 13px;
+      }
+      .card {
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 16px;
+      }
+    </style>
+
+    <!-- One block, @graph with three entities (the shape SEO apps like Yoast emit) -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Organization",
+            "name": "Acme",
+            "url": "https://acme.example",
+            "logo": "https://acme.example/logo.png",
+            "sameAs": ["https://twitter.com/acme"]
+          },
+          { "@type": "WebSite", "name": "Acme", "url": "https://acme.example" },
+          {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+              { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://acme.example/" },
+              { "@type": "ListItem", "position": 2, "name": "Catalog", "item": "https://acme.example/catalog" }
+            ]
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <aside class="expected">
+      <div class="t">Expected — Schema tab</div>
+      <ul>
+        <li>Three entities surface from one @graph block: Organization, WebSite, BreadcrumbList</li>
+        <li>
+          BreadcrumbList's itemListElement renders as a group row ("2 items") with each ListItem indented below it
+        </li>
+        <li>No badges anywhere; no red badge on the Schema sidebar tab</li>
+        <li>Summary bar: 3 types</li>
+      </ul>
+    </aside>
+    <a class="back" href="/">&larr; all test pages</a>
+    <main>
+      <div class="card">
+        All structured data lives in a single @graph array, which the tab flattens into separate rows.
+      </div>
+    </main>
+  </body>
+</html>

--- a/test-pages/schema/malformed.html
+++ b/test-pages/schema/malformed.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Mixed valid and malformed JSON-LD blocks</title>
+    <style>
+      body {
+        font:
+          15px/1.7 system-ui,
+          sans-serif;
+        margin: 0;
+        background: #fff;
+        color: #222;
+      }
+      .expected {
+        background: #eef4ff;
+        border: 1px solid #c7d8f7;
+        border-radius: 8px;
+        margin: 16px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+      .expected .t {
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .expected ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      main {
+        max-width: 680px;
+        margin: 24px auto 48px;
+        padding: 0 16px;
+      }
+      .back {
+        display: inline-block;
+        margin: 0 16px 24px;
+        font-size: 13px;
+      }
+      .card {
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 16px;
+      }
+    </style>
+
+    <!-- Valid FAQPage -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Do you ship internationally?",
+            "acceptedAnswer": { "@type": "Answer", "text": "Yes, worldwide." }
+          }
+        ]
+      }
+    </script>
+
+    <!-- Malformed: trailing comma, the single most common hand-authored JSON-LD mistake -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "Broken Markup"
+      }
+    </script>
+  </head>
+  <body>
+    <aside class="expected">
+      <div class="t">Expected — Schema tab</div>
+      <ul>
+        <li>One entity table: FAQPage (mainEntity renders as a group row with the Question/Answer indented)</li>
+        <li>One "Block 2" card with a red "invalid JSON" badge and the parser error</li>
+        <li>Summary bar: 1 type &middot; 1 invalid</li>
+        <li>The malformed block does not crash the tab</li>
+      </ul>
+    </aside>
+    <a class="back" href="/">&larr; all test pages</a>
+    <main>
+      <div class="card">
+        The second JSON-LD block has a trailing comma and fails to parse; the tab isolates it instead of breaking.
+      </div>
+    </main>
+  </body>
+</html>

--- a/test-pages/schema/mime-param.html
+++ b/test-pages/schema/mime-param.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>JSON-LD with a MIME parameter on the type attribute</title>
+    <style>
+      body {
+        font:
+          15px/1.7 system-ui,
+          sans-serif;
+        margin: 0;
+        background: #fff;
+        color: #222;
+      }
+      .expected {
+        background: #eef4ff;
+        border: 1px solid #c7d8f7;
+        border-radius: 8px;
+        margin: 16px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+      .expected .t {
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .expected ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      main {
+        max-width: 680px;
+        margin: 24px auto 48px;
+        padding: 0 16px;
+      }
+      .back {
+        display: inline-block;
+        margin: 0 16px 24px;
+        font-size: 13px;
+      }
+      .card {
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 16px;
+      }
+    </style>
+
+    <!-- type carries a charset parameter; the tab matches on the MIME essence,
+         so this block is still collected. -->
+    <script type="application/ld+json; charset=utf-8">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Charset Coffee",
+        "url": "https://charset-coffee.example"
+      }
+    </script>
+  </head>
+  <body>
+    <aside class="expected">
+      <div class="t">Expected — Schema tab</div>
+      <ul>
+        <li>One entity: Organization (despite the "; charset=utf-8" on the script type)</li>
+        <li>Summary bar: 1 type</li>
+      </ul>
+    </aside>
+    <a class="back" href="/">&larr; all test pages</a>
+    <main>
+      <div class="card">
+        The JSON-LD script declares <code>type="application/ld+json; charset=utf-8"</code> and is still detected.
+      </div>
+    </main>
+  </body>
+</html>

--- a/test-pages/schema/none.html
+++ b/test-pages/schema/none.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>No structured data (empty state)</title>
+    <style>
+      body {
+        font:
+          15px/1.7 system-ui,
+          sans-serif;
+        margin: 0;
+        background: #fff;
+        color: #222;
+      }
+      .expected {
+        background: #eef4ff;
+        border: 1px solid #c7d8f7;
+        border-radius: 8px;
+        margin: 16px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+      .expected .t {
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .expected ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      main {
+        max-width: 680px;
+        margin: 24px auto 48px;
+        padding: 0 16px;
+      }
+      .back {
+        display: inline-block;
+        margin: 0 16px 24px;
+        font-size: 13px;
+      }
+      .card {
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <aside class="expected">
+      <div class="t">Expected — Schema tab</div>
+      <ul>
+        <li>Empty state: "No structured data found on this page"</li>
+        <li>No summary bar, no badge on the Schema tab</li>
+      </ul>
+    </aside>
+    <a class="back" href="/">&larr; all test pages</a>
+    <main>
+      <div class="card">This page ships no JSON-LD at all.</div>
+    </main>
+  </body>
+</html>

--- a/test-pages/schema/product-valid.html
+++ b/test-pages/schema/product-valid.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Complete product, website, and organization markup</title>
+    <style>
+      body {
+        font:
+          15px/1.7 system-ui,
+          sans-serif;
+        margin: 0;
+        background: #fff;
+        color: #222;
+      }
+      .expected {
+        background: #eef4ff;
+        border: 1px solid #c7d8f7;
+        border-radius: 8px;
+        margin: 16px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+      .expected .t {
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .expected ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      main {
+        max-width: 680px;
+        margin: 24px auto 48px;
+        padding: 0 16px;
+      }
+      .back {
+        display: inline-block;
+        margin: 0 16px 24px;
+        font-size: 13px;
+      }
+      .card {
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 16px;
+      }
+    </style>
+
+    <!-- Organization (homepage-style identity block) -->
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "Organization",
+        "name": "Acme Coffee",
+        "url": "https://acme-coffee.example",
+        "logo": "https://acme-coffee.example/logo.png",
+        "sameAs": ["https://twitter.com/acme", "https://instagram.com/acme"]
+      }
+    </script>
+
+    <!-- WebSite with sitelinks SearchAction -->
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "WebSite",
+        "name": "Acme Coffee",
+        "url": "https://acme-coffee.example",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "https://acme-coffee.example/search?q={search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+
+    <!-- Product with a single, fully-specified Offer (note https://schema.org/ with trailing slash, as Shopify emits) -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Product",
+        "name": "Dark Roast Coffee",
+        "image": ["https://acme-coffee.example/dark-roast.jpg"],
+        "description": "A bold and balanced dark roast.",
+        "brand": { "@type": "Brand", "name": "Acme Coffee Company" },
+        "sku": "50251G",
+        "offers": {
+          "@type": "Offer",
+          "price": 19.99,
+          "priceCurrency": "USD",
+          "availability": "https://schema.org/InStock",
+          "priceValidUntil": "2027-01-01",
+          "url": "https://acme-coffee.example/products/dark-roast"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <aside class="expected">
+      <div class="t">Expected — Schema tab</div>
+      <ul>
+        <li>Three entities: Organization, WebSite, Product</li>
+        <li>Each expands to a key/value table, one property per row</li>
+        <li>Nested objects (brand, offers, potentialAction) appear as indented group rows tagged with their @type</li>
+        <li>No badges anywhere; no red badge on the Schema sidebar tab</li>
+        <li>Summary bar: 3 types</li>
+      </ul>
+    </aside>
+    <a class="back" href="/">&larr; all test pages</a>
+    <main>
+      <div class="card">
+        Dark Roast Coffee — $19.99. A clean product page whose Product, Organization, and WebSite markup is complete.
+      </div>
+    </main>
+  </body>
+</html>

--- a/test-pages/schema/product-variants.html
+++ b/test-pages/schema/product-variants.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Multi-variant product with an offers array</title>
+    <style>
+      body {
+        font:
+          15px/1.7 system-ui,
+          sans-serif;
+        margin: 0;
+        background: #fff;
+        color: #222;
+      }
+      .expected {
+        background: #eef4ff;
+        border: 1px solid #c7d8f7;
+        border-radius: 8px;
+        margin: 16px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+      .expected .t {
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .expected ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      main {
+        max-width: 680px;
+        margin: 24px auto 48px;
+        padding: 0 16px;
+      }
+      .back {
+        display: inline-block;
+        margin: 0 16px 24px;
+        font-size: 13px;
+      }
+      .card {
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 16px;
+      }
+    </style>
+
+    <!-- Product whose offers is an ARRAY (multi-variant), the shape Shopify emits
+         for products with several variants. The offers differ field-for-field. -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org/",
+        "@type": "Product",
+        "name": "Variant Tee",
+        "offers": [
+          {
+            "@type": "Offer",
+            "price": 24.99,
+            "priceCurrency": "USD",
+            "availability": "http://schema.org/InStock",
+            "priceValidUntil": "2027-01-01"
+          },
+          { "@type": "Offer", "priceCurrency": "USD", "availability": "http://schema.org/InStock" }
+        ]
+      }
+    </script>
+
+    <!-- Organization with a couple of plain string properties -->
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "Organization",
+        "name": "Acme Apparel",
+        "url": "https://acme-apparel.example"
+      }
+    </script>
+  </head>
+  <body>
+    <aside class="expected">
+      <div class="t">Expected — Schema tab</div>
+      <ul>
+        <li>Two entities: Product, Organization</li>
+        <li>Product's offers renders as a group row ("2 items") with each Offer indented below it as its own group</li>
+        <li>
+          The two offers list different fields (the second has no price) — the table shows exactly what's present,
+          nothing flagged
+        </li>
+        <li>No badges anywhere; no red badge on the Schema sidebar tab</li>
+        <li>Summary bar: 2 types</li>
+      </ul>
+    </aside>
+    <a class="back" href="/">&larr; all test pages</a>
+    <main>
+      <div class="card">
+        Variant Tee — a multi-variant product whose offers come through as an array of Offer objects.
+      </div>
+    </main>
+  </body>
+</html>

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -77,7 +77,10 @@ export type AnalyticsAction =
   | 'images_export'
   | 'images_copy'
   | 'images_sort'
-  | 'images_open';
+  | 'images_open'
+  | 'schema_view'
+  | 'schema_copy'
+  | 'schema_export';
 
 // Time savings per action (in seconds)
 const TIME_SAVINGS: Record<AnalyticsAction, number | ((metadata?: Record<string, unknown>) => number)> = {
@@ -160,7 +163,10 @@ const TIME_SAVINGS: Record<AnalyticsAction, number | ((metadata?: Record<string,
   images_export: 60,
   images_copy: 60,
   images_sort: 25,
-  images_open: 5
+  images_open: 5,
+  schema_view: 60,
+  schema_copy: 60,
+  schema_export: 60
 };
 
 // --- Usage Stats (local tracking) ---
@@ -260,7 +266,10 @@ const ACTION_CATEGORIES: Record<AnalyticsAction, string> = {
   images_export: 'SEO',
   images_copy: 'SEO',
   images_sort: 'SEO',
-  images_open: 'SEO'
+  images_open: 'SEO',
+  schema_view: 'SEO',
+  schema_copy: 'SEO',
+  schema_export: 'SEO'
 };
 
 /** Local usage stats persisted in `local:usage_stats`.

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     name: 'Alfred - Shopify Theme Detector',
     description:
       'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.06.17',
+    version: '2026.06.20',
     action: {
       default_title: 'Alfred'
     },


### PR DESCRIPTION
## Schema Analyzer (new SEO tab)

Adds a fifth popup SEO tab that lists the JSON-LD structured data on any page as clean, readable key/value tables, one per type (Product, Organization, WebSite, BreadcrumbList, and more). It's a lister, not a validator: no rich-result eligibility scoring.

### What's in it
- **Content script** (`get_schema`): scrapes every `<script type="application/ld+json">` block, captures raw text (50KB cap), records JSON parse errors, notes head/body placement.
- **Analyzer** (`analyzeSchema`): re-parses each block and flattens top-level objects, top-level arrays, and `@graph` members into separate named entities. Malformed blocks are reported separately, never thrown.
- **UI** (`Schema.svelte`): per-entity accordion; each entity flattens to a two-column table (nested objects/arrays become indented group rows tagged with their `@type`; scalar arrays stack in one cell). Per-type copy button copies just that entity's JSON (isolates one type even inside a shared `@graph`). Toolbar copy-all + JSON export. Malformed blocks shown as a red "invalid JSON" callout with the parser error.
- **Analytics**: `schema_view` / `schema_copy` / `schema_export` registered in the typed event registry.

### Tests
- `schema.test.ts`: 12 cases covering extraction, `@graph`/array flattening, `@type` normalization, and malformed-block handling.
- `test-pages/schema/`: 5 fixtures (complete markup, multi-variant offers array, nested `@graph`, malformed, empty state) with expected-output panels.
- Full suite: 190 pass / 0 fail. Typecheck + lint clean.

### Pre-landing review
Ran an adversarial code review. Fixed:
- **Duplicate table-row keys** — a BreadcrumbList with multiple ListItems produced identical `(depth+label+kind)` keys; switched to a stable per-row index key.
- **Unbounded recursion** — added a depth guard (`> 20`) in the table flattener against pathological nesting.

Deferred (noted, not blocking):
- A single JSON-LD block over the 50KB cap can show "invalid JSON" instead of "too large". Rare; would need a `truncated` flag through the content script.
- `downloadFile` revokes the object URL immediately after click — this matches the existing pattern in the Assets/Images/Links export tabs, so it's left consistent rather than changed in isolation.

Works on any website, not just Shopify stores.

---

### Follow-up: server-side analytics allowlist (found in review)

The Supabase `track` edge function only inserts events whose action is in `VALID_ACTIONS`. That list had drifted: it ended at `assets_sort`, so the new `schema_*` events were acknowledged but silently dropped — and so were the already-shipped `images_*` events and `links_toggle_hidden`. Remote analytics for those were being lost with no error.

- `supabase/functions/track/index.ts`: added `images_*` (8), `schema_*` (3), and `links_toggle_hidden` so the allowlist matches the client `AnalyticsAction` union exactly.
- New test `analytics-actions-sync.test.ts` diffs the client union against the server allowlist and fails on any future drift in either direction.

**Deploy note:** this is a Supabase edge function, not part of the extension bundle. It must be deployed separately (`supabase functions deploy track`) for the fix to take effect in production — merging the PR and releasing the extension does not deploy it.
