### PR TITLE
v2026.06.22 fix(collaborator-access): wait for all permissions before hotlink auto-submit

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "2026.06.22",
+    "date": "2026-06-22",
+    "changes": [
+      {
+        "type": "paragraph",
+        "content": "Fixed auto-submitting preset hotlinks sending the access request before every permission was added. The request now waits until all of the preset's permissions are applied, so collaborators get access to exactly what the preset specifies."
+      }
+    ]
+  },
+  {
     "version": "2026.06.20",
     "date": "2026-06-20",
     "changes": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026.06.22
+@ 2026-06-22
+Fixed auto-submitting preset hotlinks sending the access request before every permission was added. The request now waits until all of the preset's permissions are applied, so collaborators get access to exactly what the preset specifies.
+
+
 ## 2026.06.20
 @ 2026-06-20
 

--- a/entrypoints/collaborator-access.content/App.svelte
+++ b/entrypoints/collaborator-access.content/App.svelte
@@ -139,16 +139,19 @@
     }
 
     const permissions = preset.permissions ?? [];
-    setTimeout(() => {
-      permissions.forEach((permission, index) => {
-        setTimeout(() => {
-          adapter.checkPermission(permission.id);
-        }, index * 50);
-      });
+    const permissionsApplied = new Promise<void>((resolve) => {
       setTimeout(() => {
-        adapter.expandCheckedSections();
-      }, permissions.length * 50 + 50);
-    }, 100);
+        permissions.forEach((permission, index) => {
+          setTimeout(() => {
+            adapter.checkPermission(permission.id);
+          }, index * 50);
+        });
+        setTimeout(() => {
+          adapter.expandCheckedSections();
+          resolve();
+        }, permissions.length * 50 + 50);
+      }, 100);
+    });
 
     if (preset.customMessage !== '') {
       adapter.setMessage(preset.customMessage ?? '');
@@ -158,15 +161,19 @@
       window.scrollTo({ top: Math.max(document.body.scrollHeight, document.documentElement.scrollHeight), behavior: 'smooth' });
     }, 100 + permissions.length * 50 + 400);
 
-    // Optionally submit once the page actually enables the Request access button.
-    // That happens only after the store URL validates and the checked permissions
-    // register, so wait for the real enabled state instead of guessing with a timer.
+    // Optionally submit once every permission is applied AND the page enables the
+    // Request access button. The page enables the button as soon as the store URL
+    // validates and a single permission registers, so waiting on the enabled state
+    // alone fires submit mid-fill, dropping the permissions still queued behind it.
+    // Gate on the full apply schedule first, then wait for the real enabled state.
     if (autoSubmit) {
-      void adapter.waitForSubmitEnabled().then((ready) => {
-        if (ready && adapter.submit()) {
-          sendTrackEvent('preset_auto_submit', { permissions_count: permissions.length, source });
-        }
-      });
+      void permissionsApplied
+        .then(() => adapter.waitForSubmitEnabled())
+        .then((ready) => {
+          if (ready && adapter.submit()) {
+            sendTrackEvent('preset_auto_submit', { permissions_count: permissions.length, source });
+          }
+        });
     }
 
     const updatedPreset = await savePreset({ ...preset, lastUsed: Date.now() });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.06.20",
+  "version": "2026.06.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     name: 'Alfred - Shopify Theme Detector',
     description:
       'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.06.20',
+    version: '2026.06.22',
     action: {
       default_title: 'Alfred'
     },


### PR DESCRIPTION
## What

Fixes a regression on the preset hotlink auto-submit path reported on #72: the access request fired before all of the preset's permissions were applied, so collaborators were granted only a subset of the intended scopes.

## Root cause

`handleApplyPreset` applies permissions asynchronously, staggered 50ms apart (last lands at ~`100 + (N-1)*50`ms). But `adapter.waitForSubmitEnabled()` was called immediately and resolves the instant the submit button's `disabled` attribute clears. Shopify enables that button as soon as the form is *minimally* valid: store URL validated **+ one permission checked**. So once validation completed and the first permission registered, the button enabled, the observer fired, and `submit()` clicked while the remaining permissions were still queued.

PR #72 fixed the store-URL validation race but assumed "enabled" meant "all permissions applied." It doesn't.

## Fix

Wrap the permission-apply schedule in a `permissionsApplied` promise that resolves after the last `checkPermission` + `expandCheckedSections`, then gate auto-submit on it before waiting for the enabled button:

```
permissionsApplied → waitForSubmitEnabled() → submit()
```

The apply schedule is deterministic (we own those timers), so this closes the race without guessing delays. If the button is already enabled by the time apply finishes, `waitForSubmitEnabled` returns immediately.

## Verification

Differential test in an isolated headless Chromium: the **real** bundled `createAdapter` plus the verbatim pre-fix and post-fix orchestration blocks, driven against a faithful fixture of Shopify's form (button enables on store-valid + ≥1 permission), time advanced deterministically via fake clock.

- **OLD (pre-fix):** `SUBMIT-CLICK` after only **1 of 5** permissions checked. Reproduces the report.
- **NEW (fix):** submit after all **5/5** checked.
- Probes: store validates slow (600ms) → still submits 5/5; store never validates → correctly does **not** submit (no false-submit); store validates fast → 5/5.

The live authenticated Shopify page is out of harness reach, so this is the closest faithful runtime evidence; final confirmation is a manual HMR check.

## Files
- `entrypoints/collaborator-access.content/App.svelte` — gate auto-submit on all permissions applied
- `package.json`, `wxt.config.ts` — version → 2026.06.22
- `changelog.json`, `changelog.md` — release entry

## Notes
- The App.svelte content-script timing isn't unit-tested (DOM-against-live-Shopify), verified at runtime instead.
- `waitForSubmitEnabled`'s real default timeout is 3000ms (presets.ts:791); the #72 PR body said "8s". Not touched here, but worth aligning later.