### PR TITLE
v2026.06.24 feat(popup): link status checker + per-tab state persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,11 @@ This project uses WXT - a modern framework for building browser extensions.
   or `createShadowRootUi` from WXT
 - Options page settings use a module-level Svelte store
   (`entrypoints/options/stores/settings.svelte.ts`)
+- Popup per-tab view state uses a module-level Svelte store
+  (`entrypoints/popup/stores/tabState.svelte.ts`) backed by
+  `chrome.storage.session`, keyed by tab id and stamped with the page URL. App
+  and tab components hydrate from it on open and push snapshots back; it busts on
+  navigation and is cleared on tab close via `tabs.onRemoved` in the background
 - Options page uses Shopify Polaris web components (custom elements, not Svelte
   components) with polyfill helpers in `utils/polaris.polyfill.ts`
 

--- a/assets/data/themes.json
+++ b/assets/data/themes.json
@@ -2,23 +2,23 @@
   {
     "name": "Abode",
     "theme_store_id": 1918,
-    "version": "3.1.4",
+    "version": "3.1.5",
     "price": 140,
     "theme_url": "https://themes.shopify.com/themes/abode",
     "developer": {
       "name": "MUUP",
-      "url": "/designers/muup"
+      "url": "https://themes.shopify.com/designers/muup"
     }
   },
   {
     "name": "Adorn",
     "theme_store_id": 3259,
-    "version": "2.3.4",
+    "version": "2.3.5",
     "price": 270,
     "theme_url": "https://themes.shopify.com/themes/adorn",
     "developer": {
       "name": "Vowel Web",
-      "url": "/designers/vowelweb"
+      "url": "https://themes.shopify.com/designers/vowelweb"
     }
   },
   {
@@ -29,7 +29,7 @@
     "theme_url": "https://themes.shopify.com/themes/aesthetic",
     "developer": {
       "name": "Noord",
-      "url": "/designers/noordthemes"
+      "url": "https://themes.shopify.com/designers/noordthemes"
     }
   },
   {
@@ -40,7 +40,7 @@
     "theme_url": "https://themes.shopify.com/themes/agile",
     "developer": {
       "name": "NextSky",
-      "url": "/designers/nextsky1"
+      "url": "https://themes.shopify.com/designers/nextsky1"
     }
   },
   {
@@ -51,7 +51,7 @@
     "theme_url": "https://themes.shopify.com/themes/aisle",
     "developer": {
       "name": "Electric Maybe",
-      "url": "/designers/efeck1"
+      "url": "https://themes.shopify.com/designers/efeck1"
     }
   },
   {
@@ -62,7 +62,7 @@
     "theme_url": "https://themes.shopify.com/themes/alchemy",
     "developer": {
       "name": "Clean Canvas",
-      "url": "/designers/cleancanvas"
+      "url": "https://themes.shopify.com/designers/cleancanvas"
     }
   },
   {
@@ -73,7 +73,7 @@
     "theme_url": "https://themes.shopify.com/themes/align",
     "developer": {
       "name": "Company XYZ",
-      "url": "/designers/company-xyz"
+      "url": "https://themes.shopify.com/designers/company-xyz"
     }
   },
   {
@@ -84,7 +84,7 @@
     "theme_url": "https://themes.shopify.com/themes/allure",
     "developer": {
       "name": "UTD",
-      "url": "/designers/utd2"
+      "url": "https://themes.shopify.com/designers/utd2"
     }
   },
   {
@@ -95,7 +95,7 @@
     "theme_url": "https://themes.shopify.com/themes/amber",
     "developer": {
       "name": "BigStart",
-      "url": "/designers/bigstart1"
+      "url": "https://themes.shopify.com/designers/bigstart1"
     }
   },
   {
@@ -106,7 +106,7 @@
     "theme_url": "https://themes.shopify.com/themes/andaman",
     "developer": {
       "name": "Barracuda",
-      "url": "/designers/barracuda"
+      "url": "https://themes.shopify.com/designers/barracuda"
     }
   },
   {
@@ -117,7 +117,7 @@
     "theme_url": "https://themes.shopify.com/themes/area",
     "developer": {
       "name": "Softali",
-      "url": "/designers/softali"
+      "url": "https://themes.shopify.com/designers/softali"
     }
   },
   {
@@ -128,7 +128,7 @@
     "theme_url": "https://themes.shopify.com/themes/ascension",
     "developer": {
       "name": "Fuel Themes",
-      "url": "/designers/fuel-themes-official"
+      "url": "https://themes.shopify.com/designers/fuel-themes-official"
     }
   },
   {
@@ -139,62 +139,62 @@
     "theme_url": "https://themes.shopify.com/themes/ascent",
     "developer": {
       "name": "Webvista Studio",
-      "url": "/designers/gckj"
+      "url": "https://themes.shopify.com/designers/gckj"
     }
   },
   {
     "name": "Atelier",
     "theme_store_id": 3621,
-    "version": "3.5.1",
+    "version": "4.1.1",
     "price": 0,
     "theme_url": "https://themes.shopify.com/themes/atelier",
     "developer": {
       "name": "Shopify",
-      "url": "/designers/shopify"
+      "url": "https://themes.shopify.com/designers/shopify"
     }
   },
   {
     "name": "Athens",
     "theme_store_id": 1608,
-    "version": "6.5.0",
+    "version": "6.6.0",
     "price": 320,
     "theme_url": "https://themes.shopify.com/themes/athens",
     "developer": {
       "name": "Truly Fine Pixels",
-      "url": "/designers/cssigniter"
+      "url": "https://themes.shopify.com/designers/cssigniter"
     }
   },
   {
     "name": "Athora",
     "theme_store_id": 4041,
-    "version": "2.1.1",
+    "version": "2.2.2",
     "price": 340,
     "theme_url": "https://themes.shopify.com/themes/athora",
     "developer": {
       "name": "The4",
-      "url": "/designers/the4studio"
+      "url": "https://themes.shopify.com/designers/the4studio"
     }
   },
   {
     "name": "Atlantic",
     "theme_store_id": 566,
     "version": "19.2.0",
-    "price": 280,
+    "price": 300,
     "theme_url": "https://themes.shopify.com/themes/atlantic",
     "developer": {
       "name": "Pixel Union",
-      "url": "/designers/pixel-union"
+      "url": "https://themes.shopify.com/designers/pixel-union"
     }
   },
   {
     "name": "Atlas",
     "theme_store_id": 3981,
-    "version": "1.1.0",
+    "version": "1.2.0",
     "price": 280,
     "theme_url": "https://themes.shopify.com/themes/atlas",
     "developer": {
       "name": "Alloy Themes",
-      "url": "/designers/webdevstudio"
+      "url": "https://themes.shopify.com/designers/webdevstudio"
     }
   },
   {
@@ -205,29 +205,29 @@
     "theme_url": "https://themes.shopify.com/themes/atom",
     "developer": {
       "name": "Koding Themes",
-      "url": "/designers/koding-themes"
+      "url": "https://themes.shopify.com/designers/koding-themes"
     }
   },
   {
     "name": "Aurora",
     "theme_store_id": 1770,
-    "version": "5.0.2",
+    "version": "5.0.3",
     "price": 390,
     "theme_url": "https://themes.shopify.com/themes/aurora",
     "developer": {
       "name": "Getsitecontrol",
-      "url": "/designers/getsitecontrol"
+      "url": "https://themes.shopify.com/designers/getsitecontrol"
     }
   },
   {
     "name": "Avante",
     "theme_store_id": 1667,
-    "version": "14.0.0",
+    "version": "15.0.0",
     "price": 290,
     "theme_url": "https://themes.shopify.com/themes/avante",
     "developer": {
       "name": "Staylime",
-      "url": "/designers/staylime"
+      "url": "https://themes.shopify.com/designers/staylime"
     }
   },
   {
@@ -238,7 +238,7 @@
     "theme_url": "https://themes.shopify.com/themes/avenue",
     "developer": {
       "name": "Red Plug Design Co.",
-      "url": "/designers/red-plug-design-co"
+      "url": "https://themes.shopify.com/designers/red-plug-design-co"
     }
   },
   {
@@ -249,73 +249,73 @@
     "theme_url": "https://themes.shopify.com/themes/azzel",
     "developer": {
       "name": "Tapita",
-      "url": "/designers/tapita"
+      "url": "https://themes.shopify.com/designers/tapita"
     }
   },
   {
     "name": "Banjo",
     "theme_store_id": 1778,
-    "version": "4.2.0",
+    "version": "4.2.1",
     "price": 360,
     "theme_url": "https://themes.shopify.com/themes/banjo",
     "developer": {
       "name": "ThemeGoal",
-      "url": "/designers/theme-goal-design"
+      "url": "https://themes.shopify.com/designers/theme-goal-design"
     }
   },
   {
     "name": "Barcelona",
     "theme_store_id": 2324,
-    "version": "1.2.2",
+    "version": "1.3.0",
     "price": 380,
     "theme_url": "https://themes.shopify.com/themes/barcelona",
     "developer": {
       "name": "Apparent Collective",
-      "url": "/designers/apparent-collective"
+      "url": "https://themes.shopify.com/designers/apparent-collective"
     }
   },
   {
     "name": "Baseline",
     "theme_store_id": 910,
-    "version": "5.2.0",
+    "version": "5.3.0",
     "price": 400,
     "theme_url": "https://themes.shopify.com/themes/baseline",
     "developer": {
       "name": "Switch",
-      "url": "/designers/switch-themes"
+      "url": "https://themes.shopify.com/designers/switch-themes"
     }
   },
   {
     "name": "Be Yours",
     "theme_store_id": 1399,
-    "version": "8.7.0",
+    "version": "9.1.0",
     "price": 350,
     "theme_url": "https://themes.shopify.com/themes/be-yours",
     "developer": {
       "name": "RoarTheme",
-      "url": "/designers/kumi"
+      "url": "https://themes.shopify.com/designers/kumi"
     }
   },
   {
     "name": "Beautify",
     "theme_store_id": 2319,
-    "version": "1.2.0",
-    "price": 420,
+    "version": "1.3.0",
+    "price": 430,
     "theme_url": "https://themes.shopify.com/themes/beautify",
     "developer": {
       "name": "Clean Canvas",
-      "url": "/designers/cleancanvas"
+      "url": "https://themes.shopify.com/designers/cleancanvas"
     }
   },
   {
     "name": "Berlin",
     "theme_store_id": 2138,
-    "version": "1.3.2",
+    "version": "1.3.0",
     "price": 380,
     "theme_url": "https://themes.shopify.com/themes/berlin",
     "developer": {
       "name": "Apparent Collective",
-      "url": "/designers/apparent-collective"
+      "url": "https://themes.shopify.com/designers/apparent-collective"
     }
   },
   {
@@ -326,29 +326,29 @@
     "theme_url": "https://themes.shopify.com/themes/bespoke",
     "developer": {
       "name": "Red Plug Design Co.",
-      "url": "/designers/red-plug-design-co"
+      "url": "https://themes.shopify.com/designers/red-plug-design-co"
     }
   },
   {
     "name": "Beyond",
     "theme_store_id": 939,
-    "version": "7.1.1",
+    "version": "7.1.0",
     "price": 420,
     "theme_url": "https://themes.shopify.com/themes/beyond",
     "developer": {
       "name": "Troop Themes",
-      "url": "/designers/troop"
+      "url": "https://themes.shopify.com/designers/troop"
     }
   },
   {
     "name": "Blockshop",
     "theme_store_id": 606,
-    "version": "13.1.1",
+    "version": "13.1.0",
     "price": 420,
     "theme_url": "https://themes.shopify.com/themes/blockshop",
     "developer": {
       "name": "Troop Themes",
-      "url": "/designers/troop"
+      "url": "https://themes.shopify.com/designers/troop"
     }
   },
   {
@@ -359,7 +359,7 @@
     "theme_url": "https://themes.shopify.com/themes/blum",
     "developer": {
       "name": "SalesHunterThemes",
-      "url": "/designers/saleshunterthemes"
+      "url": "https://themes.shopify.com/designers/saleshunterthemes"
     }
   },
   {
@@ -370,7 +370,7 @@
     "theme_url": "https://themes.shopify.com/themes/boost",
     "developer": {
       "name": "Clean Canvas",
-      "url": "/designers/cleancanvas"
+      "url": "https://themes.shopify.com/designers/cleancanvas"
     }
   },
   {
@@ -381,7 +381,7 @@
     "theme_url": "https://themes.shopify.com/themes/borders",
     "developer": {
       "name": "Krown Themes",
-      "url": "/designers/krownthemes"
+      "url": "https://themes.shopify.com/designers/krownthemes"
     }
   },
   {
@@ -392,7 +392,7 @@
     "theme_url": "https://themes.shopify.com/themes/boutique",
     "developer": {
       "name": "UTD",
-      "url": "/designers/utd2"
+      "url": "https://themes.shopify.com/designers/utd2"
     }
   },
   {
@@ -403,7 +403,7 @@
     "theme_url": "https://themes.shopify.com/themes/brava",
     "developer": {
       "name": "Koding Themes",
-      "url": "/designers/koding-themes"
+      "url": "https://themes.shopify.com/designers/koding-themes"
     }
   },
   {
@@ -414,18 +414,18 @@
     "theme_url": "https://themes.shopify.com/themes/broadcast",
     "developer": {
       "name": "Presidio",
-      "url": "/designers/invisible-themes"
+      "url": "https://themes.shopify.com/designers/invisible-themes"
     }
   },
   {
     "name": "Bullet",
     "theme_store_id": 1114,
-    "version": "6.1.0",
+    "version": "6.0.0",
     "price": 370,
     "theme_url": "https://themes.shopify.com/themes/bullet",
     "developer": {
       "name": "OpenThinking",
-      "url": "/designers/openthinking2"
+      "url": "https://themes.shopify.com/designers/openthinking2"
     }
   },
   {
@@ -436,7 +436,7 @@
     "theme_url": "https://themes.shopify.com/themes/california",
     "developer": {
       "name": "Small Victories",
-      "url": "/designers/guille-lopez"
+      "url": "https://themes.shopify.com/designers/guille-lopez"
     }
   },
   {
@@ -447,29 +447,29 @@
     "theme_url": "https://themes.shopify.com/themes/cama",
     "developer": {
       "name": "Trafik Plus",
-      "url": "/designers/trafik-plus"
+      "url": "https://themes.shopify.com/designers/trafik-plus"
     }
   },
   {
     "name": "Canopy",
     "theme_store_id": 732,
     "version": "7.3.0",
-    "price": 400,
+    "price": 420,
     "theme_url": "https://themes.shopify.com/themes/canopy",
     "developer": {
       "name": "Clean Canvas",
-      "url": "/designers/cleancanvas"
+      "url": "https://themes.shopify.com/designers/cleancanvas"
     }
   },
   {
     "name": "Capital",
     "theme_store_id": 812,
-    "version": "36.0.3",
+    "version": "36.0.4",
     "price": 380,
     "theme_url": "https://themes.shopify.com/themes/capital",
     "developer": {
       "name": "Eight Themes",
-      "url": "/designers/weareeight"
+      "url": "https://themes.shopify.com/designers/weareeight"
     }
   },
   {
@@ -480,7 +480,7 @@
     "theme_url": "https://themes.shopify.com/themes/carbon",
     "developer": {
       "name": "E-commerce Studio",
-      "url": "/designers/karmoon"
+      "url": "https://themes.shopify.com/designers/karmoon"
     }
   },
   {
@@ -491,51 +491,51 @@
     "theme_url": "https://themes.shopify.com/themes/cascade",
     "developer": {
       "name": "Switch",
-      "url": "/designers/switch-themes"
+      "url": "https://themes.shopify.com/designers/switch-themes"
     }
   },
   {
     "name": "Cello",
     "theme_store_id": 2328,
-    "version": "3.0.6",
+    "version": "3.0.7",
     "price": 160,
     "theme_url": "https://themes.shopify.com/themes/cello",
     "developer": {
       "name": "Webibazaar Templates",
-      "url": "/designers/webibazaar"
+      "url": "https://themes.shopify.com/designers/webibazaar"
     }
   },
   {
     "name": "Charge",
     "theme_store_id": 2063,
-    "version": "3.12.0",
+    "version": "3.21.0",
     "price": 170,
     "theme_url": "https://themes.shopify.com/themes/charge",
     "developer": {
       "name": "Swissuplabs",
-      "url": "/designers/swissuplabs1"
+      "url": "https://themes.shopify.com/designers/swissuplabs1"
     }
   },
   {
     "name": "Chord",
     "theme_store_id": 1584,
-    "version": "5.2.0",
+    "version": "5.2.1",
     "price": 360,
     "theme_url": "https://themes.shopify.com/themes/chord",
     "developer": {
       "name": "ThemeGoal",
-      "url": "/designers/theme-goal-design"
+      "url": "https://themes.shopify.com/designers/theme-goal-design"
     }
   },
   {
     "name": "Colorblock",
     "theme_store_id": 1499,
-    "version": "15.4.1",
+    "version": "15.5.0",
     "price": 0,
     "theme_url": "https://themes.shopify.com/themes/colorblock",
     "developer": {
       "name": "Shopify",
-      "url": "/designers/shopify"
+      "url": "https://themes.shopify.com/designers/shopify"
     }
   },
   {
@@ -546,18 +546,18 @@
     "theme_url": "https://themes.shopify.com/themes/colors",
     "developer": {
       "name": "Small Victories",
-      "url": "/designers/guille-lopez"
+      "url": "https://themes.shopify.com/designers/guille-lopez"
     }
   },
   {
     "name": "Combine",
     "theme_store_id": 1826,
-    "version": "3.2.2",
+    "version": "4.0.0",
     "price": 380,
     "theme_url": "https://themes.shopify.com/themes/combine",
     "developer": {
       "name": "Krown Themes",
-      "url": "/designers/krownthemes"
+      "url": "https://themes.shopify.com/designers/krownthemes"
     }
   },
   {
@@ -568,18 +568,18 @@
     "theme_url": "https://themes.shopify.com/themes/concept",
     "developer": {
       "name": "RoarTheme",
-      "url": "/designers/kumi"
+      "url": "https://themes.shopify.com/designers/kumi"
     }
   },
   {
     "name": "Copenhagen",
     "theme_store_id": 2564,
-    "version": "1.2.2",
+    "version": "1.3.0",
     "price": 380,
     "theme_url": "https://themes.shopify.com/themes/copenhagen",
     "developer": {
       "name": "Apparent Collective",
-      "url": "/designers/apparent-collective"
+      "url": "https://themes.shopify.com/designers/apparent-collective"
     }
   },
   {
@@ -590,95 +590,95 @@
     "theme_url": "https://themes.shopify.com/themes/cornerstone",
     "developer": {
       "name": "Fluorescent Design Inc.",
-      "url": "/designers/fluorescent"
+      "url": "https://themes.shopify.com/designers/fluorescent"
     }
   },
   {
     "name": "Craft",
     "theme_store_id": 1368,
-    "version": "15.4.1",
+    "version": "15.5.0",
     "price": 0,
     "theme_url": "https://themes.shopify.com/themes/craft",
     "developer": {
       "name": "Shopify",
-      "url": "/designers/shopify"
+      "url": "https://themes.shopify.com/designers/shopify"
     }
   },
   {
     "name": "Crave",
     "theme_store_id": 1363,
-    "version": "15.4.1",
+    "version": "15.5.0",
     "price": 0,
     "theme_url": "https://themes.shopify.com/themes/crave",
     "developer": {
       "name": "Shopify",
-      "url": "/designers/shopify"
+      "url": "https://themes.shopify.com/designers/shopify"
     }
   },
   {
     "name": "Creative",
     "theme_store_id": 1829,
-    "version": "9.0.0",
-    "price": 380,
+    "version": "9.1.0",
+    "price": 100,
     "theme_url": "https://themes.shopify.com/themes/creative",
     "developer": {
       "name": "Safe As Milk",
-      "url": "/designers/safeasmilk"
+      "url": "https://themes.shopify.com/designers/safeasmilk"
     }
   },
   {
     "name": "Creator",
     "theme_store_id": 1922,
-    "version": "3.9.0",
+    "version": "3.10.0",
     "price": 300,
     "theme_url": "https://themes.shopify.com/themes/creator",
     "developer": {
       "name": "Purple Labs",
-      "url": "/designers/purple-labs2"
+      "url": "https://themes.shopify.com/designers/purple-labs2"
     }
   },
   {
     "name": "Dawn",
     "theme_store_id": 887,
-    "version": "15.4.1",
+    "version": "15.5.0",
     "price": 0,
     "theme_url": "https://themes.shopify.com/themes/dawn",
     "developer": {
       "name": "Shopify",
-      "url": "/designers/shopify"
+      "url": "https://themes.shopify.com/designers/shopify"
     }
   },
   {
     "name": "Desert",
     "theme_store_id": 3313,
-    "version": "1.3.2",
+    "version": "1.3.3",
     "price": 100,
     "theme_url": "https://themes.shopify.com/themes/desert",
     "developer": {
       "name": "Crown Studio",
-      "url": "/designers/premium-selective"
+      "url": "https://themes.shopify.com/designers/premium-selective"
     }
   },
   {
     "name": "Digital",
     "theme_store_id": 2539,
-    "version": "1.5.2",
+    "version": "1.6.0",
     "price": 380,
     "theme_url": "https://themes.shopify.com/themes/digital",
     "developer": {
       "name": "Segment",
-      "url": "/designers/madebysegment"
+      "url": "https://themes.shopify.com/designers/madebysegment"
     }
   },
   {
     "name": "Distinctive",
     "theme_store_id": 2431,
-    "version": "5.0.0",
+    "version": "6.0.0",
     "price": 360,
     "theme_url": "https://themes.shopify.com/themes/distinctive",
     "developer": {
       "name": "Fuel Themes",
-      "url": "/designers/fuel-themes-official"
+      "url": "https://themes.shopify.com/designers/fuel-themes-official"
     }
   },
   {
@@ -689,62 +689,62 @@
     "theme_url": "https://themes.shopify.com/themes/district",
     "developer": {
       "name": "Style Hatch, Inc",
-      "url": "/designers/style-hatch"
+      "url": "https://themes.shopify.com/designers/style-hatch"
     }
   },
   {
     "name": "Divide",
     "theme_store_id": 2273,
-    "version": "3.7.0",
+    "version": "3.8.0",
     "price": 350,
     "theme_url": "https://themes.shopify.com/themes/divide",
     "developer": {
       "name": "Squiggle & Code",
-      "url": "/designers/squiggle-code"
+      "url": "https://themes.shopify.com/designers/squiggle-code"
     }
   },
   {
     "name": "Divine",
     "theme_store_id": 2931,
-    "version": "3.2.0",
+    "version": "3.4.1",
     "price": 120,
     "theme_url": "https://themes.shopify.com/themes/divine",
     "developer": {
       "name": "Swissuplabs",
-      "url": "/designers/swissuplabs1"
+      "url": "https://themes.shopify.com/designers/swissuplabs1"
     }
   },
   {
     "name": "Drop",
     "theme_store_id": 1197,
-    "version": "5.2.0",
+    "version": "5.3.0",
     "price": 180,
     "theme_url": "https://themes.shopify.com/themes/drop",
     "developer": {
       "name": "We are Underground",
-      "url": "/designers/undergroundmedia"
+      "url": "https://themes.shopify.com/designers/undergroundmedia"
     }
   },
   {
     "name": "Dwell",
     "theme_store_id": 3623,
-    "version": "3.5.1",
+    "version": "4.1.1",
     "price": 0,
     "theme_url": "https://themes.shopify.com/themes/dwell",
     "developer": {
       "name": "Shopify",
-      "url": "/designers/shopify"
+      "url": "https://themes.shopify.com/designers/shopify"
     }
   },
   {
     "name": "Dynamic",
     "theme_store_id": 4133,
-    "version": "1.1.3",
+    "version": "1.1.6",
     "price": 290,
     "theme_url": "https://themes.shopify.com/themes/dynamic",
     "developer": {
       "name": "Vowel Web",
-      "url": "/designers/vowelweb"
+      "url": "https://themes.shopify.com/designers/vowelweb"
     }
   },
   {
@@ -755,7 +755,7 @@
     "theme_url": "https://themes.shopify.com/themes/eclipse",
     "developer": {
       "name": "Fluorescent Design Inc.",
-      "url": "/designers/fluorescent"
+      "url": "https://themes.shopify.com/designers/fluorescent"
     }
   },
   {
@@ -766,40 +766,40 @@
     "theme_url": "https://themes.shopify.com/themes/edge",
     "developer": {
       "name": "OranThemes",
-      "url": "/designers/orancreative"
+      "url": "https://themes.shopify.com/designers/orancreative"
     }
   },
   {
     "name": "Editions",
     "theme_store_id": 457,
     "version": "14.2.0",
-    "price": 100,
+    "price": 120,
     "theme_url": "https://themes.shopify.com/themes/editions",
     "developer": {
       "name": "Pixel Union",
-      "url": "/designers/pixel-union"
+      "url": "https://themes.shopify.com/designers/pixel-union"
     }
   },
   {
     "name": "Electro",
     "theme_store_id": 2164,
-    "version": "3.2.0",
+    "version": "3.3.0",
     "price": 200,
     "theme_url": "https://themes.shopify.com/themes/electro",
     "developer": {
-      "name": "SalesHunterThemes",
-      "url": "/designers/saleshunterthemes"
+      "name": "eComX",
+      "url": "https://themes.shopify.com/designers/ecomxhq"
     }
   },
   {
     "name": "Elegance",
     "theme_store_id": 4091,
-    "version": "1.1.0",
+    "version": "1.3.0",
     "price": 100,
     "theme_url": "https://themes.shopify.com/themes/elegance",
     "developer": {
-      "name": "Designthemes",
-      "url": "/designers/designthemes"
+      "name": "WeDesignTech Private Limited",
+      "url": "https://themes.shopify.com/designers/designthemes"
     }
   },
   {
@@ -810,18 +810,18 @@
     "theme_url": "https://themes.shopify.com/themes/elemento",
     "developer": {
       "name": "KROKOD sp. z o.o.",
-      "url": "/designers/krokod-sp-z-o-o"
+      "url": "https://themes.shopify.com/designers/krokod-sp-z-o-o"
     }
   },
   {
     "name": "Elixira",
     "theme_store_id": 3264,
-    "version": "4.0.4",
+    "version": "4.1.0",
     "price": 140,
     "theme_url": "https://themes.shopify.com/themes/elixira",
     "developer": {
       "name": "MUUP",
-      "url": "/designers/muup"
+      "url": "https://themes.shopify.com/designers/muup"
     }
   },
   {
@@ -832,29 +832,29 @@
     "theme_url": "https://themes.shopify.com/themes/elysian",
     "developer": {
       "name": "Koding Themes",
-      "url": "/designers/koding-themes"
+      "url": "https://themes.shopify.com/designers/koding-themes"
     }
   },
   {
     "name": "Emerge",
     "theme_store_id": 833,
-    "version": "10.1.1",
+    "version": "10.2.0",
     "price": 380,
     "theme_url": "https://themes.shopify.com/themes/emerge",
     "developer": {
       "name": "Troop Themes",
-      "url": "/designers/troop"
+      "url": "https://themes.shopify.com/designers/troop"
     }
   },
   {
     "name": "Empire",
     "theme_store_id": 838,
-    "version": "12.3.0",
-    "price": 340,
+    "version": "13.0.0",
+    "price": 360,
     "theme_url": "https://themes.shopify.com/themes/empire",
     "developer": {
       "name": "Pixel Union",
-      "url": "/designers/pixel-union"
+      "url": "https://themes.shopify.com/designers/pixel-union"
     }
   },
   {
@@ -865,7 +865,7 @@
     "theme_url": "https://themes.shopify.com/themes/emporium",
     "developer": {
       "name": "Themu",
-      "url": "/designers/themu"
+      "url": "https://themes.shopify.com/designers/themu"
     }
   },
   {
@@ -876,29 +876,29 @@
     "theme_url": "https://themes.shopify.com/themes/energy",
     "developer": {
       "name": "IT-Geeks",
-      "url": "/designers/it-geeks"
+      "url": "https://themes.shopify.com/designers/it-geeks"
     }
   },
   {
     "name": "Enterprise",
     "theme_store_id": 1657,
     "version": "2.3.0",
-    "price": 400,
+    "price": 420,
     "theme_url": "https://themes.shopify.com/themes/enterprise",
     "developer": {
       "name": "Clean Canvas",
-      "url": "/designers/cleancanvas"
+      "url": "https://themes.shopify.com/designers/cleancanvas"
     }
   },
   {
     "name": "Envy",
     "theme_store_id": 411,
-    "version": "36.0.3",
+    "version": "36.0.4",
     "price": 380,
     "theme_url": "https://themes.shopify.com/themes/envy",
     "developer": {
       "name": "Eight Themes",
-      "url": "/designers/weareeight"
+      "url": "https://themes.shopify.com/designers/weareeight"
     }
   },
   {
@@ -909,7 +909,7 @@
     "theme_url": "https://themes.shopify.com/themes/erickson",
     "developer": {
       "name": "Koding Themes",
-      "url": "/designers/koding-themes"
+      "url": "https://themes.shopify.com/designers/koding-themes"
     }
   },
   {
@@ -920,40 +920,40 @@
     "theme_url": "https://themes.shopify.com/themes/essence",
     "developer": {
       "name": "Alloy Themes",
-      "url": "/designers/webdevstudio"
+      "url": "https://themes.shopify.com/designers/webdevstudio"
     }
   },
   {
     "name": "Essentials",
     "theme_store_id": 2482,
-    "version": "1.4.2",
+    "version": "1.5.0",
     "price": 320,
     "theme_url": "https://themes.shopify.com/themes/essentials",
     "developer": {
       "name": "Noord",
-      "url": "/designers/noordthemes"
+      "url": "https://themes.shopify.com/designers/noordthemes"
     }
   },
   {
     "name": "Etheryx",
     "theme_store_id": 3248,
     "version": "1.5.0",
-    "price": 360,
+    "price": 370,
     "theme_url": "https://themes.shopify.com/themes/etheryx",
     "developer": {
       "name": "OpenThinking",
-      "url": "/designers/openthinking2"
+      "url": "https://themes.shopify.com/designers/openthinking2"
     }
   },
   {
     "name": "Eurus",
     "theme_store_id": 2048,
-    "version": "9.10.0",
+    "version": "10.0.0",
     "price": 350,
     "theme_url": "https://themes.shopify.com/themes/eurus",
     "developer": {
       "name": "BSS Commerce",
-      "url": "/designers/bss-commerce"
+      "url": "https://themes.shopify.com/designers/bss-commerce"
     }
   },
   {
@@ -964,117 +964,117 @@
     "theme_url": "https://themes.shopify.com/themes/exhibit",
     "developer": {
       "name": "Switch",
-      "url": "/designers/switch-themes"
+      "url": "https://themes.shopify.com/designers/switch-themes"
     }
   },
   {
     "name": "Expanse",
     "theme_store_id": 902,
     "version": "9.1.0",
-    "price": 400,
+    "price": 420,
     "theme_url": "https://themes.shopify.com/themes/expanse",
     "developer": {
       "name": "Archetype Themes",
-      "url": "/designers/archetypethemes"
+      "url": "https://themes.shopify.com/designers/archetypethemes"
     }
   },
   {
     "name": "Expression",
     "theme_store_id": 230,
     "version": "10.0.1",
-    "price": 280,
+    "price": 220,
     "theme_url": "https://themes.shopify.com/themes/expression",
     "developer": {
       "name": "Clean Canvas",
-      "url": "/designers/cleancanvas"
+      "url": "https://themes.shopify.com/designers/cleancanvas"
     }
   },
   {
     "name": "Fabric",
     "theme_store_id": 3622,
-    "version": "3.5.1",
+    "version": "4.1.1",
     "price": 0,
     "theme_url": "https://themes.shopify.com/themes/fabric",
     "developer": {
       "name": "Shopify",
-      "url": "/designers/shopify"
+      "url": "https://themes.shopify.com/designers/shopify"
     }
   },
   {
     "name": "Fame",
     "theme_store_id": 2101,
-    "version": "7.0.3",
+    "version": "7.0.4",
     "price": 200,
     "theme_url": "https://themes.shopify.com/themes/fame",
     "developer": {
       "name": "Shine Dezign Infonet",
-      "url": "/designers/shine-dezign-infonet"
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
     }
   },
   {
     "name": "Fashionopolism",
     "theme_store_id": 141,
-    "version": "11.0.1",
-    "price": 350,
+    "version": "11.0.2",
+    "price": 200,
     "theme_url": "https://themes.shopify.com/themes/fashionopolism",
     "developer": {
       "name": "We are Underground",
-      "url": "/designers/undergroundmedia"
+      "url": "https://themes.shopify.com/designers/undergroundmedia"
     }
   },
   {
     "name": "Filo",
     "theme_store_id": 3955,
     "version": "1.0.2",
-    "price": 100,
+    "price": 140,
     "theme_url": "https://themes.shopify.com/themes/filo",
     "developer": {
       "name": "MUUP",
-      "url": "/designers/muup"
+      "url": "https://themes.shopify.com/designers/muup"
     }
   },
   {
     "name": "Flaunt",
     "theme_store_id": 3841,
-    "version": "1.2.5",
-    "price": 290,
+    "version": "1.2.6",
+    "price": 270,
     "theme_url": "https://themes.shopify.com/themes/flaunt",
     "developer": {
       "name": "Vowel Web",
-      "url": "/designers/vowelweb"
+      "url": "https://themes.shopify.com/designers/vowelweb"
     }
   },
   {
     "name": "Flawless",
     "theme_store_id": 2847,
-    "version": "11.0.0",
-    "price": 300,
+    "version": "11.1.0",
+    "price": 320,
     "theme_url": "https://themes.shopify.com/themes/flawless",
     "developer": {
       "name": "Ascend Themes",
-      "url": "/designers/shoptrade-pte-ltd2"
+      "url": "https://themes.shopify.com/designers/shoptrade-pte-ltd2"
     }
   },
   {
     "name": "Flow",
     "theme_store_id": 801,
-    "version": "41.2.5",
+    "version": "41.2.6",
     "price": 380,
     "theme_url": "https://themes.shopify.com/themes/flow",
     "developer": {
       "name": "Eight Themes",
-      "url": "/designers/weareeight"
+      "url": "https://themes.shopify.com/designers/weareeight"
     }
   },
   {
     "name": "Flute",
     "theme_store_id": 3702,
-    "version": "1.0.4",
+    "version": "1.0.5",
     "price": 230,
     "theme_url": "https://themes.shopify.com/themes/flute",
     "developer": {
       "name": "Webibazaar Templates",
-      "url": "/designers/webibazaar"
+      "url": "https://themes.shopify.com/designers/webibazaar"
     }
   },
   {
@@ -1085,7 +1085,7 @@
     "theme_url": "https://themes.shopify.com/themes/flux",
     "developer": {
       "name": "Mana Themes",
-      "url": "/designers/anariel-design"
+      "url": "https://themes.shopify.com/designers/anariel-design"
     }
   },
   {
@@ -1096,7 +1096,2273 @@
     "theme_url": "https://themes.shopify.com/themes/focal",
     "developer": {
       "name": "Maestrooo",
-      "url": "/designers/maestrooo"
+      "url": "https://themes.shopify.com/designers/maestrooo"
+    }
+  },
+  {
+    "name": "Foodie",
+    "theme_store_id": 918,
+    "version": "6.2.0",
+    "price": 180,
+    "theme_url": "https://themes.shopify.com/themes/foodie",
+    "developer": {
+      "name": "We are Underground",
+      "url": "https://themes.shopify.com/designers/undergroundmedia"
+    }
+  },
+  {
+    "name": "Force",
+    "theme_store_id": 3822,
+    "version": "1.1.2",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/force",
+    "developer": {
+      "name": "Creative Commerce",
+      "url": "https://themes.shopify.com/designers/creative-commerce-labs"
+    }
+  },
+  {
+    "name": "Forge",
+    "theme_store_id": 1492,
+    "version": "5.2.0",
+    "price": 180,
+    "theme_url": "https://themes.shopify.com/themes/forge",
+    "developer": {
+      "name": "We are Underground",
+      "url": "https://themes.shopify.com/designers/undergroundmedia"
+    }
+  },
+  {
+    "name": "Frame",
+    "theme_store_id": 1716,
+    "version": "7.0.0",
+    "price": 160,
+    "theme_url": "https://themes.shopify.com/themes/frame",
+    "developer": {
+      "name": "Archer Commerce",
+      "url": "https://themes.shopify.com/designers/archer-commerce-inc"
+    }
+  },
+  {
+    "name": "Fullframe",
+    "theme_store_id": 3530,
+    "version": "1.1.0",
+    "price": 260,
+    "theme_url": "https://themes.shopify.com/themes/fullframe",
+    "developer": {
+      "name": "Xotiny",
+      "url": "https://themes.shopify.com/designers/xotiny"
+    }
+  },
+  {
+    "name": "Futurer",
+    "theme_store_id": 3341,
+    "version": "3.0.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/futurer",
+    "developer": {
+      "name": "Xotiny",
+      "url": "https://themes.shopify.com/designers/xotiny"
+    }
+  },
+  {
+    "name": "Gain",
+    "theme_store_id": 2077,
+    "version": "4.2.3",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/gain",
+    "developer": {
+      "name": "UTD",
+      "url": "https://themes.shopify.com/designers/utd2"
+    }
+  },
+  {
+    "name": "Galleria",
+    "theme_store_id": 851,
+    "version": "4.1.0",
+    "price": 300,
+    "theme_url": "https://themes.shopify.com/themes/galleria",
+    "developer": {
+      "name": "Mile High Themes",
+      "url": "https://themes.shopify.com/designers/mile-high-themes"
+    }
+  },
+  {
+    "name": "Genie",
+    "theme_store_id": 3574,
+    "version": "1.1.3",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/genie",
+    "developer": {
+      "name": "Shine Dezign Infonet",
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
+    }
+  },
+  {
+    "name": "Gentech",
+    "theme_store_id": 3985,
+    "version": "2.2.0",
+    "price": 360,
+    "theme_url": "https://themes.shopify.com/themes/gentech",
+    "developer": {
+      "name": "Xotiny",
+      "url": "https://themes.shopify.com/designers/xotiny"
+    }
+  },
+  {
+    "name": "Grid",
+    "theme_store_id": 718,
+    "version": "7.2.0",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/grid",
+    "developer": {
+      "name": "Pixel Union",
+      "url": "https://themes.shopify.com/designers/pixel-union"
+    }
+  },
+  {
+    "name": "Grove",
+    "theme_store_id": 3597,
+    "version": "1.3.5",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/grove",
+    "developer": {
+      "name": "Omelatte FZ-LLC",
+      "url": "https://themes.shopify.com/designers/omelatte"
+    }
+  },
+  {
+    "name": "Habitat",
+    "theme_store_id": 1581,
+    "version": "12.0.0",
+    "price": 360,
+    "theme_url": "https://themes.shopify.com/themes/habitat",
+    "developer": {
+      "name": "Fuel Themes",
+      "url": "https://themes.shopify.com/designers/fuel-themes-official"
+    }
+  },
+  {
+    "name": "Handmade",
+    "theme_store_id": 1791,
+    "version": "2.5.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/handmade",
+    "developer": {
+      "name": "Superfine",
+      "url": "https://themes.shopify.com/designers/superfinedigital"
+    }
+  },
+  {
+    "name": "Haven",
+    "theme_store_id": 3682,
+    "version": "1.4.0",
+    "price": 260,
+    "theme_url": "https://themes.shopify.com/themes/haven",
+    "developer": {
+      "name": "Hex Switch Studios",
+      "url": "https://themes.shopify.com/designers/hexswitch-studios"
+    }
+  },
+  {
+    "name": "Heritage",
+    "theme_store_id": 3624,
+    "version": "4.1.1",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/heritage",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Highlight",
+    "theme_store_id": 903,
+    "version": "4.0.2",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/highlight",
+    "developer": {
+      "name": "Krown Themes",
+      "url": "https://themes.shopify.com/designers/krownthemes"
+    }
+  },
+  {
+    "name": "Homage",
+    "theme_store_id": 4050,
+    "version": "1.1.0",
+    "price": 250,
+    "theme_url": "https://themes.shopify.com/themes/homage",
+    "developer": {
+      "name": "Ourselves",
+      "url": "https://themes.shopify.com/designers/ourselves2"
+    }
+  },
+  {
+    "name": "Honey",
+    "theme_store_id": 2160,
+    "version": "11.0.2",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/honey",
+    "developer": {
+      "name": "Archer Commerce",
+      "url": "https://themes.shopify.com/designers/archer-commerce-inc"
+    }
+  },
+  {
+    "name": "Horizon",
+    "theme_store_id": 2481,
+    "version": "3.5.1",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/horizon",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Huge",
+    "theme_store_id": 2158,
+    "version": "1.0.0",
+    "price": 290,
+    "theme_url": "https://themes.shopify.com/themes/huge",
+    "developer": {
+      "name": "BlueCap Commerce",
+      "url": "https://themes.shopify.com/designers/marketplace-solution"
+    }
+  },
+  {
+    "name": "Hyper",
+    "theme_store_id": 3247,
+    "version": "1.3.3",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/hyper",
+    "developer": {
+      "name": "FoxEcom",
+      "url": "https://themes.shopify.com/designers/foxecomoffcial"
+    }
+  },
+  {
+    "name": "Icon",
+    "theme_store_id": 686,
+    "version": "12.2.1",
+    "price": 250,
+    "theme_url": "https://themes.shopify.com/themes/icon",
+    "developer": {
+      "name": "We are Underground",
+      "url": "https://themes.shopify.com/designers/undergroundmedia"
+    }
+  },
+  {
+    "name": "Igloo",
+    "theme_store_id": 2315,
+    "version": "2.2.1",
+    "price": 160,
+    "theme_url": "https://themes.shopify.com/themes/igloo",
+    "developer": {
+      "name": "IT-Geeks",
+      "url": "https://themes.shopify.com/designers/it-geeks"
+    }
+  },
+  {
+    "name": "Ignite",
+    "theme_store_id": 3027,
+    "version": "2.5.2",
+    "price": 340,
+    "theme_url": "https://themes.shopify.com/themes/ignite",
+    "developer": {
+      "name": "Benchmark Themes",
+      "url": "https://themes.shopify.com/designers/benchmark-themes"
+    }
+  },
+  {
+    "name": "Impact",
+    "theme_store_id": 1190,
+    "version": "7.0.1",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/impact",
+    "developer": {
+      "name": "Maestrooo",
+      "url": "https://themes.shopify.com/designers/maestrooo"
+    }
+  },
+  {
+    "name": "Impulse",
+    "theme_store_id": 857,
+    "version": "9.1.0",
+    "price": 450,
+    "theme_url": "https://themes.shopify.com/themes/impulse",
+    "developer": {
+      "name": "Archetype Themes",
+      "url": "https://themes.shopify.com/designers/archetypethemes"
+    }
+  },
+  {
+    "name": "Infinity",
+    "theme_store_id": 2061,
+    "version": "3.0.0",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/infinity",
+    "developer": {
+      "name": "EM Softech  LLP",
+      "url": "https://themes.shopify.com/designers/em-softech"
+    }
+  },
+  {
+    "name": "Iris",
+    "theme_store_id": 2489,
+    "version": "3.2.0",
+    "price": 270,
+    "theme_url": "https://themes.shopify.com/themes/iris",
+    "developer": {
+      "name": "Mana Themes",
+      "url": "https://themes.shopify.com/designers/anariel-design"
+    }
+  },
+  {
+    "name": "July",
+    "theme_store_id": 4210,
+    "version": "1.0.5",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/july",
+    "developer": {
+      "name": "Webvista Studio",
+      "url": "https://themes.shopify.com/designers/gckj"
+    }
+  },
+  {
+    "name": "Kairo",
+    "theme_store_id": 1843,
+    "version": "1.2.0",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/kairo",
+    "developer": {
+      "name": "Harmoniks",
+      "url": "https://themes.shopify.com/designers/harmoniks1"
+    }
+  },
+  {
+    "name": "Keystone",
+    "theme_store_id": 2943,
+    "version": "2.2.0",
+    "price": 440,
+    "theme_url": "https://themes.shopify.com/themes/keystone",
+    "developer": {
+      "name": "Brickspace Lab",
+      "url": "https://themes.shopify.com/designers/brickspace-lab"
+    }
+  },
+  {
+    "name": "Kidu",
+    "theme_store_id": 2268,
+    "version": "4.9.1",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/kidu",
+    "developer": {
+      "name": "1o1development",
+      "url": "https://themes.shopify.com/designers/1o1development"
+    }
+  },
+  {
+    "name": "King",
+    "theme_store_id": 2948,
+    "version": "2.0.7",
+    "price": 500,
+    "theme_url": "https://themes.shopify.com/themes/king",
+    "developer": {
+      "name": "Shine Dezign Infonet",
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
+    }
+  },
+  {
+    "name": "Kingdom",
+    "theme_store_id": 725,
+    "version": "6.1.3",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/kingdom",
+    "developer": {
+      "name": "Krown Themes",
+      "url": "https://themes.shopify.com/designers/krownthemes"
+    }
+  },
+  {
+    "name": "Koto",
+    "theme_store_id": 3001,
+    "version": "2.0.6",
+    "price": 290,
+    "theme_url": "https://themes.shopify.com/themes/koto",
+    "developer": {
+      "name": "Webibazaar Templates",
+      "url": "https://themes.shopify.com/designers/webibazaar"
+    }
+  },
+  {
+    "name": "Krank",
+    "theme_store_id": 3754,
+    "version": "1.2.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/krank",
+    "developer": {
+      "name": "Webvista Studio",
+      "url": "https://themes.shopify.com/designers/gckj"
+    }
+  },
+  {
+    "name": "Line",
+    "theme_store_id": 3679,
+    "version": "1.1.0",
+    "price": 260,
+    "theme_url": "https://themes.shopify.com/themes/line",
+    "developer": {
+      "name": "Xotiny",
+      "url": "https://themes.shopify.com/designers/xotiny"
+    }
+  },
+  {
+    "name": "Local",
+    "theme_store_id": 1651,
+    "version": "4.1.1",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/local",
+    "developer": {
+      "name": "Krown Themes",
+      "url": "https://themes.shopify.com/designers/krownthemes"
+    }
+  },
+  {
+    "name": "Loft",
+    "theme_store_id": 846,
+    "version": "2.4.1",
+    "price": 180,
+    "theme_url": "https://themes.shopify.com/themes/loft",
+    "developer": {
+      "name": "Trailblaze Media",
+      "url": "https://themes.shopify.com/designers/trailblaze-media"
+    }
+  },
+  {
+    "name": "Loka",
+    "theme_store_id": 3440,
+    "version": "5.0.0",
+    "price": 140,
+    "theme_url": "https://themes.shopify.com/themes/loka",
+    "developer": {
+      "name": "MUUP",
+      "url": "https://themes.shopify.com/designers/muup"
+    }
+  },
+  {
+    "name": "Lollipop",
+    "theme_store_id": 3401,
+    "version": "3.0.0",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/lollipop",
+    "developer": {
+      "name": "WeDesignTech Private Limited",
+      "url": "https://themes.shopify.com/designers/designthemes"
+    }
+  },
+  {
+    "name": "Lorenza",
+    "theme_store_id": 798,
+    "version": "7.0.4",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/lorenza",
+    "developer": {
+      "name": "Fluorescent Design Inc.",
+      "url": "https://themes.shopify.com/designers/fluorescent"
+    }
+  },
+  {
+    "name": "Lumin",
+    "theme_store_id": 3205,
+    "version": "2.1.4",
+    "price": 290,
+    "theme_url": "https://themes.shopify.com/themes/lumin",
+    "developer": {
+      "name": "1o1development",
+      "url": "https://themes.shopify.com/designers/1o1development"
+    }
+  },
+  {
+    "name": "Lute",
+    "theme_store_id": 2171,
+    "version": "3.2.1",
+    "price": 360,
+    "theme_url": "https://themes.shopify.com/themes/lute",
+    "developer": {
+      "name": "ThemeGoal",
+      "url": "https://themes.shopify.com/designers/theme-goal-design"
+    }
+  },
+  {
+    "name": "Luxe",
+    "theme_store_id": 2779,
+    "version": "14.1.0",
+    "price": 490,
+    "theme_url": "https://themes.shopify.com/themes/luxe",
+    "developer": {
+      "name": "Winter Studio",
+      "url": "https://themes.shopify.com/designers/eightyone-creative-ltd"
+    }
+  },
+  {
+    "name": "Lyra",
+    "theme_store_id": 3533,
+    "version": "1.0.6",
+    "price": 260,
+    "theme_url": "https://themes.shopify.com/themes/lyra",
+    "developer": {
+      "name": "Webibazaar Templates",
+      "url": "https://themes.shopify.com/designers/webibazaar"
+    }
+  },
+  {
+    "name": "Machina",
+    "theme_store_id": 2883,
+    "version": "2.0.0",
+    "price": 220,
+    "theme_url": "https://themes.shopify.com/themes/machina",
+    "developer": {
+      "name": "Koding Themes",
+      "url": "https://themes.shopify.com/designers/koding-themes"
+    }
+  },
+  {
+    "name": "Madrid",
+    "theme_store_id": 2870,
+    "version": "1.6.2",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/madrid",
+    "developer": {
+      "name": "Apparent Collective",
+      "url": "https://themes.shopify.com/designers/apparent-collective"
+    }
+  },
+  {
+    "name": "Maker",
+    "theme_store_id": 765,
+    "version": "12.2.0",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/maker",
+    "developer": {
+      "name": "Troop Themes",
+      "url": "https://themes.shopify.com/designers/troop"
+    }
+  },
+  {
+    "name": "Mandolin",
+    "theme_store_id": 1696,
+    "version": "4.3.2",
+    "price": 360,
+    "theme_url": "https://themes.shopify.com/themes/mandolin",
+    "developer": {
+      "name": "ThemeGoal",
+      "url": "https://themes.shopify.com/designers/theme-goal-design"
+    }
+  },
+  {
+    "name": "Maranello",
+    "theme_store_id": 2186,
+    "version": "5.4.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/maranello",
+    "developer": {
+      "name": "Truly Fine Pixels",
+      "url": "https://themes.shopify.com/designers/cssigniter"
+    }
+  },
+  {
+    "name": "Marble",
+    "theme_store_id": 1907,
+    "version": "4.0.4",
+    "price": 250,
+    "theme_url": "https://themes.shopify.com/themes/marble",
+    "developer": {
+      "name": "BigStart",
+      "url": "https://themes.shopify.com/designers/bigstart1"
+    }
+  },
+  {
+    "name": "Masonry",
+    "theme_store_id": 450,
+    "version": "8.0.0",
+    "price": 220,
+    "theme_url": "https://themes.shopify.com/themes/masonry",
+    "developer": {
+      "name": "Clean Canvas",
+      "url": "https://themes.shopify.com/designers/cleancanvas"
+    }
+  },
+  {
+    "name": "Master",
+    "theme_store_id": 3177,
+    "version": "2.0.4",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/master",
+    "developer": {
+      "name": "Shine Dezign Infonet",
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
+    }
+  },
+  {
+    "name": "Mavon",
+    "theme_store_id": 1979,
+    "version": "12.1.1",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/mavon",
+    "developer": {
+      "name": "Gloryio",
+      "url": "https://themes.shopify.com/designers/anik-hastech"
+    }
+  },
+  {
+    "name": "Maximize",
+    "theme_store_id": 3716,
+    "version": "1.8.0",
+    "price": 200,
+    "theme_url": "https://themes.shopify.com/themes/maximize",
+    "developer": {
+      "name": "Omni Themes",
+      "url": "https://themes.shopify.com/designers/omnithemes-com"
+    }
+  },
+  {
+    "name": "Maya",
+    "theme_store_id": 3500,
+    "version": "1.0.5",
+    "price": 500,
+    "theme_url": "https://themes.shopify.com/themes/maya",
+    "developer": {
+      "name": "Shine Dezign Infonet",
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
+    }
+  },
+  {
+    "name": "Megastore",
+    "theme_store_id": 3562,
+    "version": "1.0.7",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/megastore",
+    "developer": {
+      "name": "Creative Commerce",
+      "url": "https://themes.shopify.com/designers/creative-commerce-labs"
+    }
+  },
+  {
+    "name": "Meka",
+    "theme_store_id": 2845,
+    "version": "5.0.5",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/meka",
+    "developer": {
+      "name": "MUUP",
+      "url": "https://themes.shopify.com/designers/muup"
+    }
+  },
+  {
+    "name": "Metro",
+    "theme_store_id": 3873,
+    "version": "1.0.4",
+    "price": 200,
+    "theme_url": "https://themes.shopify.com/themes/metro",
+    "developer": {
+      "name": "Shine Dezign Infonet",
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
+    }
+  },
+  {
+    "name": "Milano",
+    "theme_store_id": 4260,
+    "version": "1.0.2",
+    "price": 300,
+    "theme_url": "https://themes.shopify.com/themes/milano",
+    "developer": {
+      "name": "BrainEcom",
+      "url": "https://themes.shopify.com/designers/brainecom"
+    }
+  },
+  {
+    "name": "Minimalista",
+    "theme_store_id": 2316,
+    "version": "1.6.4",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/minimalista",
+    "developer": {
+      "name": "Segment",
+      "url": "https://themes.shopify.com/designers/madebysegment"
+    }
+  },
+  {
+    "name": "Minion",
+    "theme_store_id": 1571,
+    "version": "4.1.0",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/minion",
+    "developer": {
+      "name": "Softali",
+      "url": "https://themes.shopify.com/designers/softali"
+    }
+  },
+  {
+    "name": "Mix",
+    "theme_store_id": 3820,
+    "version": "1.2.0",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/mix",
+    "developer": {
+      "name": "Creative Commerce",
+      "url": "https://themes.shopify.com/designers/creative-commerce-labs"
+    }
+  },
+  {
+    "name": "Mode",
+    "theme_store_id": 1578,
+    "version": "5.2.0",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/mode",
+    "developer": {
+      "name": "Clean Canvas",
+      "url": "https://themes.shopify.com/designers/cleancanvas"
+    }
+  },
+  {
+    "name": "Modular",
+    "theme_store_id": 849,
+    "version": "7.0.1",
+    "price": 300,
+    "theme_url": "https://themes.shopify.com/themes/modular",
+    "developer": {
+      "name": "Presidio",
+      "url": "https://themes.shopify.com/designers/page-mill-design"
+    }
+  },
+  {
+    "name": "Modules",
+    "theme_store_id": 1795,
+    "version": "4.0.1",
+    "price": 200,
+    "theme_url": "https://themes.shopify.com/themes/modules",
+    "developer": {
+      "name": "Argo Themes",
+      "url": "https://themes.shopify.com/designers/ciprian1"
+    }
+  },
+  {
+    "name": "Mojave",
+    "theme_store_id": 1497,
+    "version": "3.0.0",
+    "price": 150,
+    "theme_url": "https://themes.shopify.com/themes/mojave",
+    "developer": {
+      "name": "DigiFist",
+      "url": "https://themes.shopify.com/designers/digifist"
+    }
+  },
+  {
+    "name": "Monaco",
+    "theme_store_id": 2125,
+    "version": "1.2.4",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/monaco",
+    "developer": {
+      "name": "Apparent Collective",
+      "url": "https://themes.shopify.com/designers/apparent-collective"
+    }
+  },
+  {
+    "name": "Monk",
+    "theme_store_id": 2515,
+    "version": "2.0.1",
+    "price": 300,
+    "theme_url": "https://themes.shopify.com/themes/monk",
+    "developer": {
+      "name": "Slash Themes",
+      "url": "https://themes.shopify.com/designers/slashthemes"
+    }
+  },
+  {
+    "name": "Mono",
+    "theme_store_id": 1818,
+    "version": "2.0.3",
+    "price": 300,
+    "theme_url": "https://themes.shopify.com/themes/mono",
+    "developer": {
+      "name": "Slash Themes",
+      "url": "https://themes.shopify.com/designers/slashthemes"
+    }
+  },
+  {
+    "name": "Monochrome",
+    "theme_store_id": 3425,
+    "version": "1.2.2",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/monochrome",
+    "developer": {
+      "name": "Superfine",
+      "url": "https://themes.shopify.com/designers/superfinedigital"
+    }
+  },
+  {
+    "name": "Motion",
+    "theme_store_id": 847,
+    "version": "11.2.0",
+    "price": 420,
+    "theme_url": "https://themes.shopify.com/themes/motion",
+    "developer": {
+      "name": "Archetype Themes",
+      "url": "https://themes.shopify.com/designers/archetypethemes"
+    }
+  },
+  {
+    "name": "Motto",
+    "theme_store_id": 3039,
+    "version": "1.4.3",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/motto",
+    "developer": {
+      "name": "Noord",
+      "url": "https://themes.shopify.com/designers/noordthemes"
+    }
+  },
+  {
+    "name": "Mr Parker",
+    "theme_store_id": 567,
+    "version": "12.0.0",
+    "price": 160,
+    "theme_url": "https://themes.shopify.com/themes/mr-parker",
+    "developer": {
+      "name": "We are Underground",
+      "url": "https://themes.shopify.com/designers/undergroundmedia"
+    }
+  },
+  {
+    "name": "Multi",
+    "theme_store_id": 2337,
+    "version": "4.0.3",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/multi",
+    "developer": {
+      "name": "Mile High Themes",
+      "url": "https://themes.shopify.com/designers/mile-high-themes"
+    }
+  },
+  {
+    "name": "Murmel",
+    "theme_store_id": 2512,
+    "version": "1.5",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/murmel",
+    "developer": {
+      "name": "Prettifyweb",
+      "url": "https://themes.shopify.com/designers/prettifyweb-ou"
+    }
+  },
+  {
+    "name": "Neat",
+    "theme_store_id": 1878,
+    "version": "2.1.1",
+    "price": 250,
+    "theme_url": "https://themes.shopify.com/themes/neat",
+    "developer": {
+      "name": "BoostifyThemes",
+      "url": "https://themes.shopify.com/designers/boostify"
+    }
+  },
+  {
+    "name": "Nexa",
+    "theme_store_id": 2820,
+    "version": "2.1.0",
+    "price": 290,
+    "theme_url": "https://themes.shopify.com/themes/nexa",
+    "developer": {
+      "name": "1o1development",
+      "url": "https://themes.shopify.com/designers/1o1development"
+    }
+  },
+  {
+    "name": "Next",
+    "theme_store_id": 2240,
+    "version": "3.5.1",
+    "price": 500,
+    "theme_url": "https://themes.shopify.com/themes/next",
+    "developer": {
+      "name": "Someone You Know",
+      "url": "https://themes.shopify.com/designers/someone-you-know"
+    }
+  },
+  {
+    "name": "Nimbus",
+    "theme_store_id": 3094,
+    "version": "1.8.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/nimbus",
+    "developer": {
+      "name": "OranThemes",
+      "url": "https://themes.shopify.com/designers/orancreative"
+    }
+  },
+  {
+    "name": "Noblesse",
+    "theme_store_id": 2546,
+    "version": "1.1.2",
+    "price": 180,
+    "theme_url": "https://themes.shopify.com/themes/noblesse",
+    "developer": {
+      "name": "Vevol Themes",
+      "url": "https://themes.shopify.com/designers/vevol-themes-ltd"
+    }
+  },
+  {
+    "name": "Noire",
+    "theme_store_id": 2926,
+    "version": "1.0.5",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/noire",
+    "developer": {
+      "name": "BoostifyThemes",
+      "url": "https://themes.shopify.com/designers/boostify"
+    }
+  },
+  {
+    "name": "Nordic",
+    "theme_store_id": 2801,
+    "version": "1.4.4",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/nordic",
+    "developer": {
+      "name": "Noord",
+      "url": "https://themes.shopify.com/designers/noordthemes"
+    }
+  },
+  {
+    "name": "Normcore",
+    "theme_store_id": 3269,
+    "version": "2.3.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/normcore",
+    "developer": {
+      "name": "eComX",
+      "url": "https://themes.shopify.com/designers/ecomxhq"
+    }
+  },
+  {
+    "name": "North",
+    "theme_store_id": 1460,
+    "version": "10.0.0",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/north",
+    "developer": {
+      "name": "Fuel Themes",
+      "url": "https://themes.shopify.com/designers/fuel-themes-official"
+    }
+  },
+  {
+    "name": "Nostalgia",
+    "theme_store_id": 2175,
+    "version": "4.1.0",
+    "price": 250,
+    "theme_url": "https://themes.shopify.com/themes/nostalgia",
+    "developer": {
+      "name": "AgniHD",
+      "url": "https://themes.shopify.com/designers/agnihd"
+    }
+  },
+  {
+    "name": "Nova",
+    "theme_store_id": 3520,
+    "version": "1.3.1",
+    "price": 350,
+    "theme_url": "https://themes.shopify.com/themes/nova",
+    "developer": {
+      "name": "Mile High Themes",
+      "url": "https://themes.shopify.com/designers/mile-high-themes"
+    }
+  },
+  {
+    "name": "Origin",
+    "theme_store_id": 1841,
+    "version": "15.5.0",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/origin",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Outsiders",
+    "theme_store_id": 2896,
+    "version": "1.2.2",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/outsiders",
+    "developer": {
+      "name": "Segment",
+      "url": "https://themes.shopify.com/designers/madebysegment"
+    }
+  },
+  {
+    "name": "Palo Alto",
+    "theme_store_id": 777,
+    "version": "9.1.0",
+    "price": 420,
+    "theme_url": "https://themes.shopify.com/themes/palo-alto",
+    "developer": {
+      "name": "Presidio",
+      "url": "https://themes.shopify.com/designers/page-mill-design"
+    }
+  },
+  {
+    "name": "Paper",
+    "theme_store_id": 1662,
+    "version": "8.1.3",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/paper",
+    "developer": {
+      "name": "Brickspace Lab",
+      "url": "https://themes.shopify.com/designers/brickspace-lab"
+    }
+  },
+  {
+    "name": "Parallax",
+    "theme_store_id": 688,
+    "version": "7.1.1",
+    "price": 260,
+    "theme_url": "https://themes.shopify.com/themes/parallax",
+    "developer": {
+      "name": "Out of the Sandbox",
+      "url": "https://themes.shopify.com/designers/out-of-the-sandbox"
+    }
+  },
+  {
+    "name": "Paris",
+    "theme_store_id": 2702,
+    "version": "1.3.4",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/paris",
+    "developer": {
+      "name": "Crown Studio",
+      "url": "https://themes.shopify.com/designers/premium-selective"
+    }
+  },
+  {
+    "name": "Pastarina",
+    "theme_store_id": 3387,
+    "version": "1.4.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/pastarina",
+    "developer": {
+      "name": "Xotiny",
+      "url": "https://themes.shopify.com/designers/xotiny"
+    }
+  },
+  {
+    "name": "Pebble",
+    "theme_store_id": 4032,
+    "version": "1.2.0",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/pebble",
+    "developer": {
+      "name": "FoxEcom",
+      "url": "https://themes.shopify.com/designers/foxecomoffcial"
+    }
+  },
+  {
+    "name": "Pesto",
+    "theme_store_id": 2275,
+    "version": "7.5.0",
+    "price": 150,
+    "theme_url": "https://themes.shopify.com/themes/pesto",
+    "developer": {
+      "name": "ShopiDevs",
+      "url": "https://themes.shopify.com/designers/shopidevs-apps"
+    }
+  },
+  {
+    "name": "Piano",
+    "theme_store_id": 2812,
+    "version": "2.0.6",
+    "price": 160,
+    "theme_url": "https://themes.shopify.com/themes/piano",
+    "developer": {
+      "name": "Webibazaar Templates",
+      "url": "https://themes.shopify.com/designers/webibazaar"
+    }
+  },
+  {
+    "name": "Pinnacle",
+    "theme_store_id": 2852,
+    "version": "10.0.0",
+    "price": 430,
+    "theme_url": "https://themes.shopify.com/themes/pinnacle",
+    "developer": {
+      "name": "Fuel Themes",
+      "url": "https://themes.shopify.com/designers/fuel-themes-official"
+    }
+  },
+  {
+    "name": "Pipeline",
+    "theme_store_id": 739,
+    "version": "8.1.1",
+    "price": 360,
+    "theme_url": "https://themes.shopify.com/themes/pipeline",
+    "developer": {
+      "name": "Groupthought",
+      "url": "https://themes.shopify.com/designers/corknine"
+    }
+  },
+  {
+    "name": "Pitch",
+    "theme_store_id": 3620,
+    "version": "4.1.1",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/pitch",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Poco",
+    "theme_store_id": 3907,
+    "version": "1.0.3",
+    "price": 220,
+    "theme_url": "https://themes.shopify.com/themes/poco",
+    "developer": {
+      "name": "Webibazaar Templates",
+      "url": "https://themes.shopify.com/designers/webibazaar"
+    }
+  },
+  {
+    "name": "Poetic",
+    "theme_store_id": 3867,
+    "version": "1.3.0",
+    "price": 180,
+    "theme_url": "https://themes.shopify.com/themes/poetic",
+    "developer": {
+      "name": "Inspired Labs",
+      "url": "https://themes.shopify.com/designers/inspired-labs2"
+    }
+  },
+  {
+    "name": "Polyform",
+    "theme_store_id": 2493,
+    "version": "4.4.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/polyform",
+    "developer": {
+      "name": "SmartBase\u00ae",
+      "url": "https://themes.shopify.com/designers/smartbase-s-r-o"
+    }
+  },
+  {
+    "name": "Portland",
+    "theme_store_id": 1924,
+    "version": "2.6.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/portland",
+    "developer": {
+      "name": "Superfine",
+      "url": "https://themes.shopify.com/designers/superfinedigital"
+    }
+  },
+  {
+    "name": "Prestige",
+    "theme_store_id": 855,
+    "version": "11.3.0",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/prestige",
+    "developer": {
+      "name": "Maestrooo",
+      "url": "https://themes.shopify.com/designers/maestrooo"
+    }
+  },
+  {
+    "name": "Primavera",
+    "theme_store_id": 3365,
+    "version": "1.6.1",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/primavera",
+    "developer": {
+      "name": "Ultramarina",
+      "url": "https://themes.shopify.com/designers/ultramarine"
+    }
+  },
+  {
+    "name": "Prompt",
+    "theme_store_id": 4156,
+    "version": "1.1.3",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/prompt",
+    "developer": {
+      "name": "Noord",
+      "url": "https://themes.shopify.com/designers/noordthemes"
+    }
+  },
+  {
+    "name": "Publisher",
+    "theme_store_id": 1864,
+    "version": "15.5.0",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/publisher",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Purely",
+    "theme_store_id": 3105,
+    "version": "1.0.4",
+    "price": 150,
+    "theme_url": "https://themes.shopify.com/themes/purely",
+    "developer": {
+      "name": "BoostifyThemes",
+      "url": "https://themes.shopify.com/designers/boostify"
+    }
+  },
+  {
+    "name": "Purity",
+    "theme_store_id": 3605,
+    "version": "1.1.0",
+    "price": 300,
+    "theme_url": "https://themes.shopify.com/themes/purity",
+    "developer": {
+      "name": "NextSky",
+      "url": "https://themes.shopify.com/designers/nextsky1"
+    }
+  },
+  {
+    "name": "Pursuit",
+    "theme_store_id": 1654,
+    "version": "2.1",
+    "price": 350,
+    "theme_url": "https://themes.shopify.com/themes/pursuit",
+    "developer": {
+      "name": "Mile High Themes",
+      "url": "https://themes.shopify.com/designers/mile-high-themes"
+    }
+  },
+  {
+    "name": "Rad",
+    "theme_store_id": 2970,
+    "version": "2.0.2",
+    "price": 260,
+    "theme_url": "https://themes.shopify.com/themes/rad",
+    "developer": {
+      "name": "Radikal",
+      "url": "https://themes.shopify.com/designers/radikal"
+    }
+  },
+  {
+    "name": "Redefine",
+    "theme_store_id": 3007,
+    "version": "2.2.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/redefine",
+    "developer": {
+      "name": "Xotiny",
+      "url": "https://themes.shopify.com/designers/xotiny"
+    }
+  },
+  {
+    "name": "Refine",
+    "theme_store_id": 2782,
+    "version": "4.3.0",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/refine",
+    "developer": {
+      "name": "AgniHD",
+      "url": "https://themes.shopify.com/designers/agnihd"
+    }
+  },
+  {
+    "name": "Reformation",
+    "theme_store_id": 1762,
+    "version": "12.0.0",
+    "price": 430,
+    "theme_url": "https://themes.shopify.com/themes/reformation",
+    "developer": {
+      "name": "Fuel Themes",
+      "url": "https://themes.shopify.com/designers/fuel-themes-official"
+    }
+  },
+  {
+    "name": "Refresh",
+    "theme_store_id": 1567,
+    "version": "15.4.1",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/refresh",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Relax",
+    "theme_store_id": 2477,
+    "version": "2.12.0",
+    "price": 170,
+    "theme_url": "https://themes.shopify.com/themes/relax",
+    "developer": {
+      "name": "Swissuplabs",
+      "url": "https://themes.shopify.com/designers/swissuplabs1"
+    }
+  },
+  {
+    "name": "Release",
+    "theme_store_id": 2698,
+    "version": "2.0.5",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/release",
+    "developer": {
+      "name": "DigiFist",
+      "url": "https://themes.shopify.com/designers/digifist"
+    }
+  },
+  {
+    "name": "Responsive",
+    "theme_store_id": 304,
+    "version": "10.1.1",
+    "price": 240,
+    "theme_url": "https://themes.shopify.com/themes/responsive",
+    "developer": {
+      "name": "Out of the Sandbox",
+      "url": "https://themes.shopify.com/designers/out-of-the-sandbox"
+    }
+  },
+  {
+    "name": "Retina",
+    "theme_store_id": 601,
+    "version": "8.1.0",
+    "price": 220,
+    "theme_url": "https://themes.shopify.com/themes/retina",
+    "developer": {
+      "name": "Out of the Sandbox",
+      "url": "https://themes.shopify.com/designers/out-of-the-sandbox"
+    }
+  },
+  {
+    "name": "Retro",
+    "theme_store_id": 2630,
+    "version": "2.0.0",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/retro",
+    "developer": {
+      "name": "Slash Themes",
+      "url": "https://themes.shopify.com/designers/slashthemes"
+    }
+  },
+  {
+    "name": "Ride",
+    "theme_store_id": 1500,
+    "version": "15.5.0",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/ride",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Rise",
+    "theme_store_id": 2738,
+    "version": "15.5.0",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/rise",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Ritual",
+    "theme_store_id": 3625,
+    "version": "4.1.1",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/ritual",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Roam",
+    "theme_store_id": 1777,
+    "version": "8.0.4",
+    "price": 140,
+    "theme_url": "https://themes.shopify.com/themes/roam",
+    "developer": {
+      "name": "Red Plug Design Co.",
+      "url": "https://themes.shopify.com/designers/red-plug-design-co"
+    }
+  },
+  {
+    "name": "Sahara",
+    "theme_store_id": 1926,
+    "version": "3.0.2",
+    "price": 250,
+    "theme_url": "https://themes.shopify.com/themes/sahara",
+    "developer": {
+      "name": "DigiFist",
+      "url": "https://themes.shopify.com/designers/digifist"
+    }
+  },
+  {
+    "name": "Sampo",
+    "theme_store_id": 3470,
+    "version": "5.0.0",
+    "price": 390,
+    "theme_url": "https://themes.shopify.com/themes/sampo",
+    "developer": {
+      "name": "Woolman",
+      "url": "https://themes.shopify.com/designers/woolman"
+    }
+  },
+  {
+    "name": "San Francisco",
+    "theme_store_id": 3210,
+    "version": "2.3.5",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/san-francisco",
+    "developer": {
+      "name": "Apparent Collective",
+      "url": "https://themes.shopify.com/designers/apparent-collective"
+    }
+  },
+  {
+    "name": "Satoshi",
+    "theme_store_id": 2881,
+    "version": "13.0.0",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/satoshi",
+    "developer": {
+      "name": "scandiweb",
+      "url": "https://themes.shopify.com/designers/scandiweb7"
+    }
+  },
+  {
+    "name": "Savor",
+    "theme_store_id": 3626,
+    "version": "4.1.1",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/savor",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Select",
+    "theme_store_id": 2372,
+    "version": "1.3.3",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/select",
+    "developer": {
+      "name": "Segment",
+      "url": "https://themes.shopify.com/designers/madebysegment"
+    }
+  },
+  {
+    "name": "Sense",
+    "theme_store_id": 1356,
+    "version": "15.5.0",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/sense",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Seventh",
+    "theme_store_id": 4090,
+    "version": "2.1.1",
+    "price": 420,
+    "theme_url": "https://themes.shopify.com/themes/seventh",
+    "developer": {
+      "name": "Krown Themes",
+      "url": "https://themes.shopify.com/designers/krownthemes"
+    }
+  },
+  {
+    "name": "Shapes",
+    "theme_store_id": 1535,
+    "version": "4.4.0",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/shapes",
+    "developer": {
+      "name": "Switch",
+      "url": "https://themes.shopify.com/designers/switch-themes"
+    }
+  },
+  {
+    "name": "Shark",
+    "theme_store_id": 2619,
+    "version": "2.0.3",
+    "price": 200,
+    "theme_url": "https://themes.shopify.com/themes/shark",
+    "developer": {
+      "name": "Shine Dezign Infonet",
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
+    }
+  },
+  {
+    "name": "Shift",
+    "theme_store_id": 4239,
+    "version": "1.0.6",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/shift",
+    "developer": {
+      "name": "Apparent Collective",
+      "url": "https://themes.shopify.com/designers/apparent-collective"
+    }
+  },
+  {
+    "name": "Shine",
+    "theme_store_id": 2576,
+    "version": "3.3.0",
+    "price": 210,
+    "theme_url": "https://themes.shopify.com/themes/shine",
+    "developer": {
+      "name": "eComX",
+      "url": "https://themes.shopify.com/designers/ecomxhq"
+    }
+  },
+  {
+    "name": "ShowTime",
+    "theme_store_id": 687,
+    "version": "8.2.0",
+    "price": 330,
+    "theme_url": "https://themes.shopify.com/themes/showtime",
+    "developer": {
+      "name": "Mile High Themes",
+      "url": "https://themes.shopify.com/designers/mile-high-themes"
+    }
+  },
+  {
+    "name": "Showcase",
+    "theme_store_id": 677,
+    "version": "10.2.0",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/showcase",
+    "developer": {
+      "name": "Clean Canvas",
+      "url": "https://themes.shopify.com/designers/cleancanvas"
+    }
+  },
+  {
+    "name": "Sitar",
+    "theme_store_id": 2599,
+    "version": "2.0.7",
+    "price": 160,
+    "theme_url": "https://themes.shopify.com/themes/sitar",
+    "developer": {
+      "name": "Winter Infotech",
+      "url": "https://themes.shopify.com/designers/winter-infotech"
+    }
+  },
+  {
+    "name": "Sleek",
+    "theme_store_id": 2821,
+    "version": "2.3.0",
+    "price": 350,
+    "theme_url": "https://themes.shopify.com/themes/sleek",
+    "developer": {
+      "name": "FoxEcom",
+      "url": "https://themes.shopify.com/designers/foxecomoffcial"
+    }
+  },
+  {
+    "name": "Soul",
+    "theme_store_id": 2825,
+    "version": "5.1.0",
+    "price": 190,
+    "theme_url": "https://themes.shopify.com/themes/soul",
+    "developer": {
+      "name": "HaloThemes",
+      "url": "https://themes.shopify.com/designers/envora-software-co-ltd"
+    }
+  },
+  {
+    "name": "Space",
+    "theme_store_id": 2659,
+    "version": "2.2.3",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/space",
+    "developer": {
+      "name": "Brickspace Lab",
+      "url": "https://themes.shopify.com/designers/brickspace-lab"
+    }
+  },
+  {
+    "name": "Spark",
+    "theme_store_id": 911,
+    "version": "4.0.4",
+    "price": 200,
+    "theme_url": "https://themes.shopify.com/themes/spark",
+    "developer": {
+      "name": "Fluorescent Design Inc.",
+      "url": "https://themes.shopify.com/designers/fluorescent"
+    }
+  },
+  {
+    "name": "Split",
+    "theme_store_id": 842,
+    "version": "5.0.2",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/split",
+    "developer": {
+      "name": "Krown Themes",
+      "url": "https://themes.shopify.com/designers/krownthemes"
+    }
+  },
+  {
+    "name": "Spotlight",
+    "theme_store_id": 1891,
+    "version": "15.5.0",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/spotlight",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Starlite",
+    "theme_store_id": 2455,
+    "version": "4.0.5",
+    "price": 220,
+    "theme_url": "https://themes.shopify.com/themes/starlite",
+    "developer": {
+      "name": "Shine Dezign Infonet",
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
+    }
+  },
+  {
+    "name": "Startup",
+    "theme_store_id": 652,
+    "version": "13.2.0",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/startup",
+    "developer": {
+      "name": "Pixel Union",
+      "url": "https://themes.shopify.com/designers/pixel-union"
+    }
+  },
+  {
+    "name": "Stiletto",
+    "theme_store_id": 1621,
+    "version": "6.0.1",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/stiletto",
+    "developer": {
+      "name": "Fluorescent Design Inc.",
+      "url": "https://themes.shopify.com/designers/fluorescent"
+    }
+  },
+  {
+    "name": "Stockholm",
+    "theme_store_id": 1405,
+    "version": "2.4.4",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/stockholm",
+    "developer": {
+      "name": "Superfine",
+      "url": "https://themes.shopify.com/designers/superfinedigital"
+    }
+  },
+  {
+    "name": "Stockist",
+    "theme_store_id": 3773,
+    "version": "1.2.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/stockist",
+    "developer": {
+      "name": "Noord",
+      "url": "https://themes.shopify.com/designers/noordthemes"
+    }
+  },
+  {
+    "name": "Stockmart",
+    "theme_store_id": 2105,
+    "version": "1.5.3",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/stockmart",
+    "developer": {
+      "name": "Segment",
+      "url": "https://themes.shopify.com/designers/madebysegment"
+    }
+  },
+  {
+    "name": "Story",
+    "theme_store_id": 864,
+    "version": "5.1.0",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/story",
+    "developer": {
+      "name": "Groupthought",
+      "url": "https://themes.shopify.com/designers/corknine"
+    }
+  },
+  {
+    "name": "Streamline",
+    "theme_store_id": 872,
+    "version": "7.2.0",
+    "price": 420,
+    "theme_url": "https://themes.shopify.com/themes/streamline",
+    "developer": {
+      "name": "Archetype Themes",
+      "url": "https://themes.shopify.com/designers/archetypethemes"
+    }
+  },
+  {
+    "name": "Stretch",
+    "theme_store_id": 1765,
+    "version": "2.0.1",
+    "price": 400,
+    "theme_url": "https://themes.shopify.com/themes/stretch",
+    "developer": {
+      "name": "Maestrooo",
+      "url": "https://themes.shopify.com/designers/maestrooo"
+    }
+  },
+  {
+    "name": "Strong",
+    "theme_store_id": 3385,
+    "version": "1.0.4",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/strong",
+    "developer": {
+      "name": "BoostifyThemes",
+      "url": "https://themes.shopify.com/designers/boostify"
+    }
+  },
+  {
+    "name": "Studio",
+    "theme_store_id": 1431,
+    "version": "15.5.0",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/studio",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "StyleScape",
+    "theme_store_id": 2238,
+    "version": "4.0.0",
+    "price": 250,
+    "theme_url": "https://themes.shopify.com/themes/stylescape",
+    "developer": {
+      "name": "Baad Themes",
+      "url": "https://themes.shopify.com/designers/abderrahimbaad"
+    }
+  },
+  {
+    "name": "Sunrise",
+    "theme_store_id": 57,
+    "version": "13.01.02",
+    "price": 240,
+    "theme_url": "https://themes.shopify.com/themes/sunrise",
+    "developer": {
+      "name": "Rawsterne Web Design & Illustration",
+      "url": "https://themes.shopify.com/designers/patternhead"
+    }
+  },
+  {
+    "name": "Supreme",
+    "theme_store_id": 3745,
+    "version": "1.0.6",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/supreme",
+    "developer": {
+      "name": "Grixio",
+      "url": "https://themes.shopify.com/designers/grixio"
+    }
+  },
+  {
+    "name": "Sweet",
+    "theme_store_id": 3933,
+    "version": "1.0.1",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/sweet",
+    "developer": {
+      "name": "Omelatte FZ-LLC",
+      "url": "https://themes.shopify.com/designers/omelatte"
+    }
+  },
+  {
+    "name": "Swipe",
+    "theme_store_id": 2737,
+    "version": "1.4.2",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/swipe",
+    "developer": {
+      "name": "Segment",
+      "url": "https://themes.shopify.com/designers/madebysegment"
+    }
+  },
+  {
+    "name": "Swiss",
+    "theme_store_id": 3038,
+    "version": "2.0.0",
+    "price": 280,
+    "theme_url": "https://themes.shopify.com/themes/swiss",
+    "developer": {
+      "name": "Slash Themes",
+      "url": "https://themes.shopify.com/designers/slashthemes"
+    }
+  },
+  {
+    "name": "Sydney",
+    "theme_store_id": 2117,
+    "version": "1.4.3",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/sydney",
+    "developer": {
+      "name": "Apparent Collective",
+      "url": "https://themes.shopify.com/designers/apparent-collective"
+    }
+  },
+  {
+    "name": "Symmetry",
+    "theme_store_id": 568,
+    "version": "8.3.1",
+    "price": 420,
+    "theme_url": "https://themes.shopify.com/themes/symmetry",
+    "developer": {
+      "name": "Clean Canvas",
+      "url": "https://themes.shopify.com/designers/cleancanvas"
+    }
+  },
+  {
+    "name": "Taiga",
+    "theme_store_id": 1751,
+    "version": "8.1.0",
+    "price": 500,
+    "theme_url": "https://themes.shopify.com/themes/taiga",
+    "developer": {
+      "name": "Woolman",
+      "url": "https://themes.shopify.com/designers/woolman"
+    }
+  },
+  {
+    "name": "Tailor",
+    "theme_store_id": 1457,
+    "version": "4.1.0",
+    "price": 360,
+    "theme_url": "https://themes.shopify.com/themes/tailor",
+    "developer": {
+      "name": "Pixel Union",
+      "url": "https://themes.shopify.com/designers/pixel-union"
+    }
+  },
+  {
+    "name": "Takeout",
+    "theme_store_id": 2534,
+    "version": "5.2.0",
+    "price": 190,
+    "theme_url": "https://themes.shopify.com/themes/takeout",
+    "developer": {
+      "name": "Ecom Noon",
+      "url": "https://themes.shopify.com/designers/ecomnoon"
+    }
+  },
+  {
+    "name": "Taste",
+    "theme_store_id": 1434,
+    "version": "15.5.0",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/taste",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Testament",
+    "theme_store_id": 623,
+    "version": "15.3.0",
+    "price": 250,
+    "theme_url": "https://themes.shopify.com/themes/testament",
+    "developer": {
+      "name": "We are Underground",
+      "url": "https://themes.shopify.com/designers/undergroundmedia"
+    }
+  },
+  {
+    "name": "Tinker",
+    "theme_store_id": 3627,
+    "version": "4.1.1",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/tinker",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Tokyo",
+    "theme_store_id": 2629,
+    "version": "4.3.0",
+    "price": 250,
+    "theme_url": "https://themes.shopify.com/themes/tokyo",
+    "developer": {
+      "name": "Truly Fine Pixels",
+      "url": "https://themes.shopify.com/designers/cssigniter"
+    }
+  },
+  {
+    "name": "Toyo",
+    "theme_store_id": 2358,
+    "version": "5.1.0",
+    "price": 140,
+    "theme_url": "https://themes.shopify.com/themes/toyo",
+    "developer": {
+      "name": "MUUP",
+      "url": "https://themes.shopify.com/designers/muup"
+    }
+  },
+  {
+    "name": "Trade",
+    "theme_store_id": 2699,
+    "version": "15.5.0",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/trade",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Ultra",
+    "theme_store_id": 2967,
+    "version": "2.2.3",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/ultra",
+    "developer": {
+      "name": "UTD",
+      "url": "https://themes.shopify.com/designers/doo-mind-web"
+    }
+  },
+  {
+    "name": "Unicorn",
+    "theme_store_id": 2264,
+    "version": "5.0.0",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/unicorn",
+    "developer": {
+      "name": "MPIthemes",
+      "url": "https://themes.shopify.com/designers/mpthemes"
+    }
+  },
+  {
+    "name": "Unity",
+    "theme_store_id": 3805,
+    "version": "1.0.4",
+    "price": 150,
+    "theme_url": "https://themes.shopify.com/themes/unity",
+    "developer": {
+      "name": "BoostifyThemes",
+      "url": "https://themes.shopify.com/designers/boostify"
+    }
+  },
+  {
+    "name": "Urban",
+    "theme_store_id": 2405,
+    "version": "2.2.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/urban",
+    "developer": {
+      "name": "1o1development",
+      "url": "https://themes.shopify.com/designers/1o1development"
+    }
+  },
+  {
+    "name": "Urge",
+    "theme_store_id": 2213,
+    "version": null,
+    "price": 220,
+    "theme_url": "https://themes.shopify.com/themes/urge",
+    "developer": {
+      "name": "BlueCap Commerce",
+      "url": "https://themes.shopify.com/designers/marketplace-solution"
+    }
+  },
+  {
+    "name": "Vantage",
+    "theme_store_id": 459,
+    "version": "12.2.0",
+    "price": 150,
+    "theme_url": "https://themes.shopify.com/themes/vantage",
+    "developer": {
+      "name": "We are Underground",
+      "url": "https://themes.shopify.com/designers/undergroundmedia"
+    }
+  },
+  {
+    "name": "Veena",
+    "theme_store_id": 2566,
+    "version": "2.0.8",
+    "price": 240,
+    "theme_url": "https://themes.shopify.com/themes/veena",
+    "developer": {
+      "name": "Webibazaar Templates",
+      "url": "https://themes.shopify.com/designers/webibazaar"
+    }
+  },
+  {
+    "name": "Venue",
+    "theme_store_id": 836,
+    "version": "18.2.2",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/venue",
+    "developer": {
+      "name": "Safe As Milk",
+      "url": "https://themes.shopify.com/designers/safeasmilk"
+    }
+  },
+  {
+    "name": "Vessel",
+    "theme_store_id": 3628,
+    "version": "3.5.1",
+    "price": 0,
+    "theme_url": "https://themes.shopify.com/themes/vessel",
+    "developer": {
+      "name": "Shopify",
+      "url": "https://themes.shopify.com/designers/shopify"
+    }
+  },
+  {
+    "name": "Vetro",
+    "theme_store_id": 3784,
+    "version": "3.0.0",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/vetro",
+    "developer": {
+      "name": "The4",
+      "url": "https://themes.shopify.com/designers/the4studio"
+    }
+  },
+  {
+    "name": "Victory",
+    "theme_store_id": 3830,
+    "version": "1.1.1",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/victory",
+    "developer": {
+      "name": "UTD",
+      "url": "https://themes.shopify.com/designers/utd2"
+    }
+  },
+  {
+    "name": "Vincent",
+    "theme_store_id": 2913,
+    "version": "1.5.2",
+    "price": 340,
+    "theme_url": "https://themes.shopify.com/themes/vincent",
+    "developer": {
+      "name": "Moodboard Creations",
+      "url": "https://themes.shopify.com/designers/daily-baby"
+    }
+  },
+  {
+    "name": "Viola",
+    "theme_store_id": 1701,
+    "version": "2.0.6",
+    "price": 210,
+    "theme_url": "https://themes.shopify.com/themes/viola",
+    "developer": {
+      "name": "Webibazaar Templates",
+      "url": "https://themes.shopify.com/designers/webibazaar"
+    }
+  },
+  {
+    "name": "Vision",
+    "theme_store_id": 2053,
+    "version": "15.0.0",
+    "price": 430,
+    "theme_url": "https://themes.shopify.com/themes/vision",
+    "developer": {
+      "name": "Fuel Themes",
+      "url": "https://themes.shopify.com/designers/fuel-themes-official"
+    }
+  },
+  {
+    "name": "Vivid",
+    "theme_store_id": 2285,
+    "version": "2.0.2",
+    "price": 300,
+    "theme_url": "https://themes.shopify.com/themes/vivid",
+    "developer": {
+      "name": "Slash Themes",
+      "url": "https://themes.shopify.com/designers/slashthemes"
+    }
+  },
+  {
+    "name": "Volume",
+    "theme_store_id": 2837,
+    "version": "6.0.0",
+    "price": 290,
+    "theme_url": "https://themes.shopify.com/themes/volume",
+    "developer": {
+      "name": "Staylime",
+      "url": "https://themes.shopify.com/designers/staylime"
+    }
+  },
+  {
+    "name": "Warehouse",
+    "theme_store_id": 871,
+    "version": "7.0.1",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/warehouse",
+    "developer": {
+      "name": "Maestrooo",
+      "url": "https://themes.shopify.com/designers/maestrooo"
+    }
+  },
+  {
+    "name": "Whisk",
+    "theme_store_id": 1819,
+    "version": "15.2.0",
+    "price": 310,
+    "theme_url": "https://themes.shopify.com/themes/whisk",
+    "developer": {
+      "name": "Coquelicot",
+      "url": "https://themes.shopify.com/designers/coquelicot"
+    }
+  },
+  {
+    "name": "Wonder",
+    "theme_store_id": 2684,
+    "version": "2.4.1",
+    "price": 390,
+    "theme_url": "https://themes.shopify.com/themes/wonder",
+    "developer": {
+      "name": "NETHYPE",
+      "url": "https://themes.shopify.com/designers/nethype-co"
+    }
+  },
+  {
+    "name": "Woodstock",
+    "theme_store_id": 2239,
+    "version": "3.2.0",
+    "price": 270,
+    "theme_url": "https://themes.shopify.com/themes/woodstock",
+    "developer": {
+      "name": "Boostheme",
+      "url": "https://themes.shopify.com/designers/boostheme"
+    }
+  },
+  {
+    "name": "Xclusive",
+    "theme_store_id": 2221,
+    "version": "3.6.0",
+    "price": 500,
+    "theme_url": "https://themes.shopify.com/themes/xclusive",
+    "developer": {
+      "name": "Someone You Know",
+      "url": "https://themes.shopify.com/designers/someone-you-know"
+    }
+  },
+  {
+    "name": "Xtra",
+    "theme_store_id": 1609,
+    "version": "8.0.0",
+    "price": 100,
+    "theme_url": "https://themes.shopify.com/themes/xtra",
+    "developer": {
+      "name": "Someone You Know",
+      "url": "https://themes.shopify.com/designers/someone-you-know"
+    }
+  },
+  {
+    "name": "Yuva",
+    "theme_store_id": 1615,
+    "version": "13.0.4",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/yuva",
+    "developer": {
+      "name": "Shine Dezign Infonet",
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
+    }
+  },
+  {
+    "name": "Zap",
+    "theme_store_id": 4098,
+    "version": "1.0.1",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/zap",
+    "developer": {
+      "name": "Almost Perfect Studio",
+      "url": "https://themes.shopify.com/designers/almost-perfect-studio"
+    }
+  },
+  {
+    "name": "Zeal",
+    "theme_store_id": 4036,
+    "version": "1.1.4",
+    "price": 270,
+    "theme_url": "https://themes.shopify.com/themes/zeal",
+    "developer": {
+      "name": "Fresco Solutions",
+      "url": "https://themes.shopify.com/designers/fresco-solution"
+    }
+  },
+  {
+    "name": "Zenith",
+    "theme_store_id": 3872,
+    "version": "1.4.3",
+    "price": 380,
+    "theme_url": "https://themes.shopify.com/themes/zenith",
+    "developer": {
+      "name": "Apparent Collective",
+      "url": "https://themes.shopify.com/designers/apparent-collective"
+    }
+  },
+  {
+    "name": "Zero",
+    "theme_store_id": 3300,
+    "version": "2.1.2",
+    "price": 320,
+    "theme_url": "https://themes.shopify.com/themes/zero",
+    "developer": {
+      "name": "Omelatte FZ-LLC",
+      "url": "https://themes.shopify.com/designers/omelatte"
+    }
+  },
+  {
+    "name": "Zest",
+    "theme_store_id": 1611,
+    "version": "9.3.0",
+    "price": 330,
+    "theme_url": "https://themes.shopify.com/themes/zest",
+    "developer": {
+      "name": "FoxEcom",
+      "url": "https://themes.shopify.com/designers/foxecomoffcial"
+    }
+  },
+  {
+    "name": "Zora",
+    "theme_store_id": 2505,
+    "version": "2.0.2",
+    "price": 300,
+    "theme_url": "https://themes.shopify.com/themes/zora",
+    "developer": {
+      "name": "NOVL",
+      "url": "https://themes.shopify.com/designers/novl"
+    }
+  },
+  {
+    "name": "Zyra",
+    "theme_store_id": 3802,
+    "version": "1.0.5",
+    "price": 220,
+    "theme_url": "https://themes.shopify.com/themes/zyra",
+    "developer": {
+      "name": "Shine Dezign Infonet",
+      "url": "https://themes.shopify.com/designers/shine-dezign-infonet"
     }
   }
 ]

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,27 @@
 [
   {
+    "version": "2026.06.23",
+    "date": "2026-06-23",
+    "changes": [
+      {
+        "type": "heading",
+        "content": "Link Status Checker"
+      },
+      {
+        "type": "paragraph",
+        "content": "The Links tab can now tell you whether each link actually works. Press the check button in the new Status column and Alfred checks every link, reporting whether it's live (2xx), redirecting (3xx), broken (4xx/5xx), or unreachable."
+      },
+      {
+        "type": "list",
+        "content": [
+          "Filter to just the failing links to track down broken links fast.",
+          "Sort by status to bring the worst offenders to the top.",
+          "Checks are paced and back off automatically on busy sites, so they stay reliable."
+        ]
+      }
+    ]
+  },
+  {
     "version": "2026.06.22",
     "date": "2026-06-22",
     "changes": [

--- a/changelog.json
+++ b/changelog.json
@@ -1,7 +1,7 @@
 [
   {
-    "version": "2026.06.23",
-    "date": "2026-06-23",
+    "version": "2026.06.24",
+    "date": "2026-06-24",
     "changes": [
       {
         "type": "heading",
@@ -15,8 +15,23 @@
         "type": "list",
         "content": [
           "Filter to just the failing links to track down broken links fast.",
-          "Sort by status to bring the worst offenders to the top.",
-          "Checks are paced and back off automatically on busy sites, so they stay reliable."
+          "Sort by status to bring the worst offenders to the top."
+        ]
+      },
+      {
+        "type": "heading",
+        "content": "The Popup Remembers Where You Left Off"
+      },
+      {
+        "type": "paragraph",
+        "content": "Run a link or image check, set up filters, sort a column, or expand a section, then close the popup to click something on the page. Reopen it on the same page and everything is right where you left it, including the tab you had open."
+      },
+      {
+        "type": "list",
+        "content": [
+          "Link and image status results, filters, sorting, search, and highlights are all restored.",
+          "Every browser tab keeps its own state, so different pages don't bleed into each other.",
+          "State clears automatically when you navigate to a new page or close the tab."
         ]
       }
     ]

--- a/changelog.json
+++ b/changelog.json
@@ -33,6 +33,10 @@
           "Every browser tab keeps its own state, so different pages don't bleed into each other.",
           "State clears automatically when you navigate to a new page or close the tab."
         ]
+      },
+      {
+        "type": "video",
+        "content": "https://bucket.alfred.uptek.com/alfred-links-status.mp4"
       }
     ]
   },

--- a/changelog.md
+++ b/changelog.md
@@ -1,14 +1,20 @@
 # Changelog
 
-## 2026.06.23
-@ 2026-06-23
+## 2026.06.24
+@ 2026-06-24
 
 ### Link Status Checker
 The Links tab can now tell you whether each link actually works. Press the check button in the new Status column and Alfred checks every link, reporting whether it's live (2xx), redirecting (3xx), broken (4xx/5xx), or unreachable.
 
 - Filter to just the failing links to track down broken links fast.
 - Sort by status to bring the worst offenders to the top.
-- Checks are paced and back off automatically on busy sites, so they stay reliable.
+
+### The Popup Remembers Where You Left Off
+Run a link or image check, set up filters, sort a column, or expand a section, then close the popup to click something on the page. Reopen it on the same page and everything is right where you left it, including the tab you had open.
+
+- Link and image status results, filters, sorting, search, and highlights are all restored.
+- Every browser tab keeps its own state, so different pages don't bleed into each other.
+- State clears automatically when you navigate to a new page or close the tab.
 
 ## 2026.06.22
 @ 2026-06-22

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@ Run a link or image check, set up filters, sort a column, or expand a section, t
 - Every browser tab keeps its own state, so different pages don't bleed into each other.
 - State clears automatically when you navigate to a new page or close the tab.
 
+<video controls autoplay loop muted playsinline src="https://bucket.alfred.uptek.com/alfred-links-status.mp4"></video>
+
 ## 2026.06.22
 @ 2026-06-22
 Fixed auto-submitting preset hotlinks sending the access request before every permission was added. The request now waits until all of the preset's permissions are applied, so collaborators get access to exactly what the preset specifies.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026.06.23
+@ 2026-06-23
+
+### Link Status Checker
+The Links tab can now tell you whether each link actually works. Press the check button in the new Status column and Alfred checks every link, reporting whether it's live (2xx), redirecting (3xx), broken (4xx/5xx), or unreachable.
+
+- Filter to just the failing links to track down broken links fast.
+- Sort by status to bring the worst offenders to the top.
+- Checks are paced and back off automatically on busy sites, so they stay reliable.
+
 ## 2026.06.22
 @ 2026-06-22
 Fixed auto-submitting preset hotlinks sending the access request before every permission was added. The request now waits until all of the preset's permissions are applied, so collaborators get access to exactly what the preset specifies.

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -107,7 +107,9 @@ export default defineBackground(() => {
   // keeps checks alive after the popup closes and uses host permissions to read
   // cross-origin status codes. Returning true keeps the channel open for the
   // async sendResponse.
-  browser.runtime.onMessage.addListener((message: { action?: string; url?: string }, _sender, sendResponse) => {
+  browser.runtime.onMessage.addListener((message: { action?: string; url?: string }, sender, sendResponse) => {
+    // Only honor requests from the extension's own contexts (popup/content scripts).
+    if (sender.id !== browser.runtime.id) return false;
     if (message.action === 'check_link_status' && typeof message.url === 'string') {
       checkLinkStatus(message.url).then(sendResponse);
       return true;

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -1,5 +1,6 @@
 import { storage } from '#imports';
 import { registerShortcuts } from './shortcuts';
+import { checkLinkStatus } from './linkStatus';
 import { trackAction, type AnalyticsAction } from '@/utils/analytics';
 import { saveReturnUrl, isValidReturnUrl } from '@/utils/storefrontPasswordRedirect';
 import { refreshThemesCacheIfNeeded } from '@/utils/themesCache';
@@ -100,6 +101,18 @@ export default defineBackground(() => {
         console.error('Failed to track action:', error);
       }
     }
+  });
+
+  // Resolve link HTTP statuses for the popup. Fetching here (not in the popup)
+  // keeps checks alive after the popup closes and uses host permissions to read
+  // cross-origin status codes. Returning true keeps the channel open for the
+  // async sendResponse.
+  browser.runtime.onMessage.addListener((message: { action?: string; url?: string }, _sender, sendResponse) => {
+    if (message.action === 'check_link_status' && typeof message.url === 'string') {
+      checkLinkStatus(message.url).then(sendResponse);
+      return true;
+    }
+    return false;
   });
 
   browser.runtime.onInstalled.addListener(async (details) => {

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -117,6 +117,13 @@ export default defineBackground(() => {
     return false;
   });
 
+  // The popup persists per-tab view state (open section, link-status scan) under
+  // session:popupTabState:<tabId>. Drop it the moment the tab closes so the state
+  // dies with the tab and session storage doesn't accumulate orphaned records.
+  browser.tabs.onRemoved.addListener((tabId) => {
+    storage.removeItem(`session:popupTabState:${tabId}`).catch(() => {});
+  });
+
   browser.runtime.onInstalled.addListener(async (details) => {
     // Prefetch themes cache on install and update
     refreshThemesCacheIfNeeded();

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -1,6 +1,7 @@
 import { storage } from '#imports';
 import { registerShortcuts } from './shortcuts';
 import { checkLinkStatus } from './linkStatus';
+import { keyFor } from '@/entrypoints/popup/stores/tabState';
 import { trackAction, type AnalyticsAction } from '@/utils/analytics';
 import { saveReturnUrl, isValidReturnUrl } from '@/utils/storefrontPasswordRedirect';
 import { refreshThemesCacheIfNeeded } from '@/utils/themesCache';
@@ -117,11 +118,11 @@ export default defineBackground(() => {
     return false;
   });
 
-  // The popup persists per-tab view state (open section, link-status scan) under
-  // session:popupTabState:<tabId>. Drop it the moment the tab closes so the state
-  // dies with the tab and session storage doesn't accumulate orphaned records.
+  // The popup persists per-tab view state (open section, link-status scan) keyed
+  // by tab id. Drop it the moment the tab closes so the state dies with the tab
+  // and session storage doesn't accumulate orphaned records.
   browser.tabs.onRemoved.addListener((tabId) => {
-    storage.removeItem(`session:popupTabState:${tabId}`).catch(() => {});
+    storage.removeItem(keyFor(tabId)).catch(() => {});
   });
 
   browser.runtime.onInstalled.addListener(async (details) => {

--- a/entrypoints/background/linkStatus.ts
+++ b/entrypoints/background/linkStatus.ts
@@ -26,32 +26,35 @@ export function retryAfterMs(res: Response): number {
   return DEFAULT_RETRY_WAIT_MS;
 }
 
-async function probeOnce(url: string): Promise<{ result: LinkStatusResult; retryAfter?: number }> {
+// Each probe gets its own timeout budget so a slow HEAD can't starve the GET
+// fallback (which would falsely report a healthy link as unreachable).
+async function fetchProbe(url: string, method: 'HEAD' | 'GET'): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
-    let res = await fetch(url, { method: 'HEAD', redirect: 'manual', signal: controller.signal });
+    return await fetch(url, { method, redirect: 'manual', signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function probeOnce(url: string): Promise<{ result: LinkStatusResult; retryAfter?: number }> {
+  try {
+    let res = await fetchProbe(url, 'HEAD');
     if (res.type === 'opaqueredirect') {
-      return { result: { status: 0, bucket: 'redirect', redirected: true } };
+      return { result: { status: 0, bucket: 'redirect' } };
     }
     if (res.status === 405 || res.status === 501) {
-      res = await fetch(url, { method: 'GET', redirect: 'manual', signal: controller.signal });
+      res = await fetchProbe(url, 'GET');
       if (res.type === 'opaqueredirect') {
-        return { result: { status: 0, bucket: 'redirect', redirected: true } };
+        return { result: { status: 0, bucket: 'redirect' } };
       }
     }
-    const result: LinkStatusResult = {
-      status: res.status,
-      bucket: bucketFor(res.status),
-      redirected: res.redirected,
-      ...(res.url ? { finalUrl: res.url } : {})
-    };
+    const result: LinkStatusResult = { status: res.status, bucket: bucketFor(res.status) };
     if (res.status === 429 || res.status === 503) return { result, retryAfter: retryAfterMs(res) };
     return { result };
   } catch {
-    return { result: { status: 0, bucket: 'error', redirected: false } };
-  } finally {
-    clearTimeout(timer);
+    return { result: { status: 0, bucket: 'error' } };
   }
 }
 

--- a/entrypoints/background/linkStatus.ts
+++ b/entrypoints/background/linkStatus.ts
@@ -32,9 +32,20 @@ async function fetchProbe(url: string, method: 'HEAD' | 'GET'): Promise<Response
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
-    // credentials:'include' sends each target its own cookies, so login-gated
-    // links report their real status to the signed-in user instead of 401/403.
-    return await fetch(url, { method, redirect: 'manual', credentials: 'include', signal: controller.signal });
+    // cache:'no-store' stops a stale cached 200 from masking a link that now
+    // 404s. credentials:'include' sends each target its own cookies so login-
+    // gated links report their real status to the signed-in user.
+    const res = await fetch(url, {
+      method,
+      redirect: 'manual',
+      cache: 'no-store',
+      credentials: 'include',
+      signal: controller.signal
+    });
+    // Only status/headers are needed; release the body so a large GET fallback
+    // doesn't keep buffering and tie up the connection during a sweep.
+    res.body?.cancel().catch(() => {});
+    return res;
   } finally {
     clearTimeout(timer);
   }
@@ -46,7 +57,9 @@ async function probeOnce(url: string): Promise<{ result: LinkStatusResult; retry
     if (res.type === 'opaqueredirect') {
       return { result: { status: 0, bucket: 'redirect' } };
     }
-    if (res.status === 405 || res.status === 501) {
+    // Some servers/WAFs reject HEAD with 403/404 (or 405/501) even when a real
+    // GET works, so confirm those failures with GET before trusting them.
+    if (res.status === 403 || res.status === 404 || res.status === 405 || res.status === 501) {
       res = await fetchProbe(url, 'GET');
       if (res.type === 'opaqueredirect') {
         return { result: { status: 0, bucket: 'redirect' } };

--- a/entrypoints/background/linkStatus.ts
+++ b/entrypoints/background/linkStatus.ts
@@ -1,0 +1,74 @@
+import type { LinkStatusBucket, LinkStatusResult } from '@/entrypoints/popup/utils/types';
+
+const TIMEOUT_MS = 8000;
+const MAX_RETRY_WAIT_MS = 8000;
+const DEFAULT_RETRY_WAIT_MS = 2000;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function bucketFor(status: number): LinkStatusBucket {
+  if (status >= 200 && status < 300) return 'ok';
+  if (status >= 300 && status < 400) return 'redirect';
+  if (status >= 400 && status < 500) return 'client-error';
+  if (status >= 500) return 'server-error';
+  return 'error';
+}
+
+// Honour a 429/503 Retry-After (seconds or HTTP date), capped so one slow link
+// can't stall the whole sweep.
+function retryAfterMs(res: Response): number {
+  const raw = res.headers.get('retry-after');
+  if (!raw) return DEFAULT_RETRY_WAIT_MS;
+  const secs = Number(raw);
+  if (Number.isFinite(secs)) return Math.min(Math.max(secs, 0) * 1000, MAX_RETRY_WAIT_MS);
+  const when = Date.parse(raw);
+  if (!Number.isNaN(when)) return Math.max(0, Math.min(when - Date.now(), MAX_RETRY_WAIT_MS));
+  return DEFAULT_RETRY_WAIT_MS;
+}
+
+async function probeOnce(url: string): Promise<{ result: LinkStatusResult; retryAfter?: number }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    let res = await fetch(url, { method: 'HEAD', redirect: 'manual', signal: controller.signal });
+    if (res.type === 'opaqueredirect') {
+      return { result: { status: 0, bucket: 'redirect', redirected: true } };
+    }
+    if (res.status === 405 || res.status === 501) {
+      res = await fetch(url, { method: 'GET', redirect: 'manual', signal: controller.signal });
+      if (res.type === 'opaqueredirect') {
+        return { result: { status: 0, bucket: 'redirect', redirected: true } };
+      }
+    }
+    const result: LinkStatusResult = {
+      status: res.status,
+      bucket: bucketFor(res.status),
+      redirected: res.redirected,
+      ...(res.url ? { finalUrl: res.url } : {})
+    };
+    if (res.status === 429 || res.status === 503) return { result, retryAfter: retryAfterMs(res) };
+    return { result };
+  } catch {
+    return { result: { status: 0, bucket: 'error', redirected: false } };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Checks a URL's HTTP status from the service worker, where `<all_urls>` host
+ * permissions let fetches bypass CORS and read real cross-origin status codes.
+ *
+ * HEAD avoids downloading bodies and minimises side effects; GET is a fallback
+ * only when a server rejects HEAD. `redirect: 'manual'` surfaces redirects as
+ * opaque responses (status 0), so 3xx is reported as a bucket, not an exact code.
+ *
+ * On a 429/503 it backs off once (honouring Retry-After) before reporting, so a
+ * transient rate-limit doesn't get logged as a hard failure.
+ */
+export async function checkLinkStatus(url: string): Promise<LinkStatusResult> {
+  const first = await probeOnce(url);
+  if (first.retryAfter === undefined) return first.result;
+  await sleep(first.retryAfter);
+  return (await probeOnce(url)).result;
+}

--- a/entrypoints/background/linkStatus.ts
+++ b/entrypoints/background/linkStatus.ts
@@ -6,7 +6,7 @@ const DEFAULT_RETRY_WAIT_MS = 2000;
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
-function bucketFor(status: number): LinkStatusBucket {
+export function bucketFor(status: number): LinkStatusBucket {
   if (status >= 200 && status < 300) return 'ok';
   if (status >= 300 && status < 400) return 'redirect';
   if (status >= 400 && status < 500) return 'client-error';
@@ -16,7 +16,7 @@ function bucketFor(status: number): LinkStatusBucket {
 
 // Honour a 429/503 Retry-After (seconds or HTTP date), capped so one slow link
 // can't stall the whole sweep.
-function retryAfterMs(res: Response): number {
+export function retryAfterMs(res: Response): number {
   const raw = res.headers.get('retry-after');
   if (!raw) return DEFAULT_RETRY_WAIT_MS;
   const secs = Number(raw);

--- a/entrypoints/background/linkStatus.ts
+++ b/entrypoints/background/linkStatus.ts
@@ -32,7 +32,9 @@ async function fetchProbe(url: string, method: 'HEAD' | 'GET'): Promise<Response
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
-    return await fetch(url, { method, redirect: 'manual', signal: controller.signal });
+    // credentials:'include' sends each target its own cookies, so login-gated
+    // links report their real status to the signed-in user instead of 401/403.
+    return await fetch(url, { method, redirect: 'manual', credentials: 'include', signal: controller.signal });
   } finally {
     clearTimeout(timer);
   }

--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -11,9 +11,11 @@
   import Schema from './Schema.svelte';
   import Settings from './Settings.svelte';
   import ReviewPrompt from './ReviewPrompt.svelte';
+  import { getTabState, type PopupSection } from './stores/tabState.svelte';
   import type { StoreInfo, RawHeading, RawLink, RawAsset, RawImage, RawSchemaBlock } from './utils/types';
 
-  type TabId = 'theme' | 'headings' | 'links' | 'assets' | 'images' | 'schema' | 'settings';
+  type TabId = PopupSection;
+  const tabState = getTabState();
   // Future tabs: 'apps' | 'products' | 'overview' | 'hreflangs' | 'social' | 'robots' | 'sitemaps'
 
   interface Tab {
@@ -68,13 +70,15 @@
 
   $effect(() => {
     const fetchData = async () => {
+      const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
       const [storeData, headingsData, linksData, assetsData, imagesData, schemaData] = await Promise.all([
         getTheme(),
         getHeadings(),
         getLinks(),
         getAssets(),
         getImages(),
-        getSchema()
+        getSchema(),
+        tab?.id != null && tab.url ? tabState.hydrate(tab.id, tab.url) : Promise.resolve()
       ]);
       trackAction('popup_open', { is_shopify: storeData?.isShopify ?? false });
       storeInfo = storeData;
@@ -83,12 +87,20 @@
       rawAssets = assetsData;
       rawImages = imagesData;
       rawSchema = schemaData;
-      if (!storeData?.isShopify) {
+      // A restored section wins; otherwise non-Shopify pages skip the Theme tab.
+      if (tabState.restoredActiveSection) {
+        activeTab = tabState.restoredActiveSection;
+      } else if (!storeData?.isShopify) {
         activeTab = 'headings';
       }
       loading = false;
     };
     fetchData();
+  });
+
+  // Persist the open section per tab once the initial restore has settled.
+  $effect(() => {
+    if (!loading) tabState.setActiveSection(activeTab);
   });
 </script>
 

--- a/entrypoints/popup/Assets.svelte
+++ b/entrypoints/popup/Assets.svelte
@@ -366,8 +366,6 @@
           <div class="export menu">
             <button class="export__trigger" onclick={() => { openMenu = openMenu === 'export' ? null : 'export'; }} title="Download assets">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="export__icon"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-              Export
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="export__chevron"><path d="M6 9l6 6 6-6"/></svg>
             </button>
             {#if openMenu === 'export'}
               <div class="export__menu">
@@ -529,7 +527,6 @@
   .export__trigger { display: flex; align-items: center; gap: 4px; padding: 0 8px; height: 28px; border-radius: 6px; border: 1px solid var(--border-strong); background: var(--bg); font-family: inherit; font-size: 11px; font-weight: 600; color: var(--text-muted); cursor: pointer; transition: all 0.12s; }
   .export__trigger:hover { border-color: var(--border-hover); color: var(--text-secondary); }
   .export__icon { width: 13px; height: 13px; flex-shrink: 0; stroke-width: 1.8; }
-  .export__chevron { width: 10px; height: 10px; stroke-width: 2; opacity: 0.6; }
   .export__menu { position: absolute; top: calc(100% + 4px); right: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: var(--shadow-pop); z-index: 10; min-width: 150px; padding: 4px; }
   .export__item { display: flex; align-items: center; justify-content: space-between; width: 100%; padding: 6px 10px; border: none; background: none; font-family: inherit; font-size: 12px; cursor: pointer; border-radius: 5px; transition: background 0.1s; }
   .export__item:hover { background: var(--bg-hover); }

--- a/entrypoints/popup/Assets.svelte
+++ b/entrypoints/popup/Assets.svelte
@@ -59,6 +59,10 @@
   let searchInput = $state<HTMLInputElement | null>(null);
   let expanded = $state<Set<number>>(new Set(restored?.expanded ?? []));
 
+  // Serialize the expanded set only when it actually changes, so high-frequency
+  // search/filter edits below don't re-spread it every keystroke.
+  const expandedArr = $derived([...expanded]);
+
   // Mirror the persisted slice into the per-tab cache on change (the store
   // debounces the write), so filters, sort, search, and expanded rows survive the
   // popup closing and reopening on the same page.
@@ -72,7 +76,7 @@
       sourceFilter,
       loadFilter,
       flagFilter,
-      expanded: [...expanded]
+      expanded: expandedArr
     });
   });
 

--- a/entrypoints/popup/Assets.svelte
+++ b/entrypoints/popup/Assets.svelte
@@ -7,6 +7,7 @@
   import type { SummaryItem } from './SummaryBar.svelte';
   import { trackAction } from '@/utils/analytics';
   import { untrack, onDestroy } from 'svelte';
+  import { getTabState } from './stores/tabState.svelte';
 
   let { assets, domain }: { assets: RawAsset[]; domain: string | null } = $props();
 
@@ -27,20 +28,53 @@
   });
 
   type SortKey = 'index' | 'src' | 'size' | 'time' | 'type' | 'load';
-  let sortKey = $state<SortKey>('index');
-  let sortDir = $state<'asc' | 'desc'>('asc');
 
-  let search = $state('');
-  let searchOpen = $state(false);
+  interface AssetsPersisted {
+    sortKey: SortKey;
+    sortDir: 'asc' | 'desc';
+    search: string;
+    searchOpen: boolean;
+    typeFilter: string;
+    sourceFilter: string;
+    loadFilter: string;
+    flagFilter: string;
+    expanded: number[];
+  }
+
+  const tabState = getTabState();
+  const restored = tabState.getSection<AssetsPersisted>('assets');
+
+  let sortKey = $state<SortKey>(restored?.sortKey ?? 'index');
+  let sortDir = $state<'asc' | 'desc'>(restored?.sortDir ?? 'asc');
+
+  let search = $state(restored?.search ?? '');
+  let searchOpen = $state(restored?.searchOpen ?? false);
   let openMenu = $state<'type' | 'source' | 'load' | 'flag' | 'export' | null>(null);
-  let typeFilter = $state('all');
-  let sourceFilter = $state('all');
-  let loadFilter = $state('all');
-  let flagFilter = $state('all');
+  let typeFilter = $state(restored?.typeFilter ?? 'all');
+  let sourceFilter = $state(restored?.sourceFilter ?? 'all');
+  let loadFilter = $state(restored?.loadFilter ?? 'all');
+  let flagFilter = $state(restored?.flagFilter ?? 'all');
   let copied = $state(false);
   let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
   let searchInput = $state<HTMLInputElement | null>(null);
-  let expanded = $state<Set<number>>(new Set());
+  let expanded = $state<Set<number>>(new Set(restored?.expanded ?? []));
+
+  // Mirror the persisted slice into the per-tab cache on change (the store
+  // debounces the write), so filters, sort, search, and expanded rows survive the
+  // popup closing and reopening on the same page.
+  $effect(() => {
+    tabState.saveSection('assets', {
+      sortKey,
+      sortDir,
+      search,
+      searchOpen,
+      typeFilter,
+      sourceFilter,
+      loadFilter,
+      flagFilter,
+      expanded: [...expanded]
+    });
+  });
 
   function toggleSearch() {
     searchOpen = !searchOpen;

--- a/entrypoints/popup/Assets.svelte
+++ b/entrypoints/popup/Assets.svelte
@@ -364,7 +364,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
           </button>
           <div class="export menu">
-            <button class="export__trigger" onclick={() => { openMenu = openMenu === 'export' ? null : 'export'; }} title="Download assets">
+            <button class="export__trigger" onclick={() => { openMenu = openMenu === 'export' ? null : 'export'; }} aria-label="Download assets" title="Download assets">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="export__icon"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
             </button>
             {#if openMenu === 'export'}

--- a/entrypoints/popup/Headings.svelte
+++ b/entrypoints/popup/Headings.svelte
@@ -101,7 +101,7 @@
             {hiddenCount}
           </button>
         {/if}
-        <button class="copy-btn" onclick={handleCopy} title="Copy headings to clipboard">
+        <button class="copy-btn" onclick={handleCopy} aria-label="Copy headings to clipboard" title="Copy headings to clipboard">
           {#if copyState === 'copied'}
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="copy-btn__icon"><polyline points="20 6 9 17 4 12"/></svg>
           {:else}

--- a/entrypoints/popup/Headings.svelte
+++ b/entrypoints/popup/Headings.svelte
@@ -107,7 +107,6 @@
           {:else}
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="copy-btn__icon"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
           {/if}
-          Copy
         </button>
       </div>
     </div>

--- a/entrypoints/popup/Headings.svelte
+++ b/entrypoints/popup/Headings.svelte
@@ -3,6 +3,7 @@
   import { scrollToHeading } from './utils/utils';
   import { trackAction } from '@/utils/analytics';
   import { untrack } from 'svelte';
+  import { getTabState } from './stores/tabState.svelte';
 
   let { headings, issues }: { headings: RawHeading[]; issues: HeadingIssue[] } = $props();
 
@@ -15,7 +16,18 @@
     });
   });
 
-  let showHidden = $state(true);
+  interface HeadingsPersisted {
+    showHidden: boolean;
+  }
+
+  const tabState = getTabState();
+  const restored = tabState.getSection<HeadingsPersisted>('headings');
+
+  let showHidden = $state(restored?.showHidden ?? true);
+
+  $effect(() => {
+    tabState.saveSection('headings', { showHidden });
+  });
 
   const hiddenCount = $derived(headings.filter(h => h.isHidden).length);
 

--- a/entrypoints/popup/Images.svelte
+++ b/entrypoints/popup/Images.svelte
@@ -7,7 +7,8 @@
   import type { SummaryItem } from './SummaryBar.svelte';
   import { highlightImages, scrollToImage } from './utils/utils';
   import { trackAction } from '@/utils/analytics';
-  import { untrack, onDestroy } from 'svelte';
+  import { untrack, onDestroy, onMount } from 'svelte';
+  import { getTabState } from './stores/tabState.svelte';
 
   let { images, domain }: { images: RawImage[]; domain: string | null } = $props();
 
@@ -36,23 +37,64 @@
     });
   });
 
-  let altFilter = $state('all');
-  let formatFilter = $state('all');
-  let loadingFilter = $state('all');
-  let statusFilter = $state('all');
-  let flagFilter = $state('all');
-  let search = $state('');
-  let searchOpen = $state(false);
+  type SortKey = 'index' | 'size' | 'format' | 'dims' | 'load' | 'status';
+
+  interface ImagesPersisted {
+    altFilter: string;
+    formatFilter: string;
+    loadingFilter: string;
+    statusFilter: string;
+    flagFilter: string;
+    search: string;
+    searchOpen: boolean;
+    highlightOn: boolean;
+    sortKey: SortKey;
+    sortDir: 'asc' | 'desc';
+  }
+
+  const tabState = getTabState();
+  const restored = tabState.getSection<ImagesPersisted>('images');
+
+  let altFilter = $state(restored?.altFilter ?? 'all');
+  let formatFilter = $state(restored?.formatFilter ?? 'all');
+  let loadingFilter = $state(restored?.loadingFilter ?? 'all');
+  let statusFilter = $state(restored?.statusFilter ?? 'all');
+  let flagFilter = $state(restored?.flagFilter ?? 'all');
+  let search = $state(restored?.search ?? '');
+  let searchOpen = $state(restored?.searchOpen ?? false);
   let openMenu = $state<'alt' | 'format' | 'loading' | 'status' | 'flag' | 'export' | null>(null);
 
-  type SortKey = 'index' | 'size' | 'format' | 'dims' | 'load' | 'status';
-  let sortKey = $state<SortKey>('index');
-  let sortDir = $state<'asc' | 'desc'>('asc');
+  let sortKey = $state<SortKey>(restored?.sortKey ?? 'index');
+  let sortDir = $state<'asc' | 'desc'>(restored?.sortDir ?? 'asc');
 
   let copied = $state(false);
   let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
-  let highlightOn = $state(false);
+  let highlightOn = $state(restored?.highlightOn ?? false);
   let searchInput = $state<HTMLInputElement | null>(null);
+
+  // onDestroy strips the on-page outlines when the popup closes, so re-apply them
+  // if the restored state had highlighting on.
+  onMount(() => {
+    if (highlightOn) highlightImages(true);
+  });
+
+  // Mirror the persisted slice into the per-tab cache on change (the store
+  // debounces the write), so filters, sort, search, and highlight survive the
+  // popup closing and reopening on the same page.
+  $effect(() => {
+    tabState.saveSection('images', {
+      altFilter,
+      formatFilter,
+      loadingFilter,
+      statusFilter,
+      flagFilter,
+      search,
+      searchOpen,
+      highlightOn,
+      sortKey,
+      sortDir
+    });
+  });
 
   function toggleSearch() {
     searchOpen = !searchOpen;

--- a/entrypoints/popup/Images.svelte
+++ b/entrypoints/popup/Images.svelte
@@ -358,14 +358,14 @@
           {/if}
         </div>
         <div class="toolbar__actions">
-          <button class="toolbar-btn" class:toolbar-btn--active={highlightOn} onclick={toggleHighlight} title="Highlight images on page">
+          <button class="toolbar-btn" class:toolbar-btn--active={highlightOn} onclick={toggleHighlight} aria-label="Highlight images on page" title="Highlight images on page">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>
           </button>
           <button class="toolbar-btn" class:toolbar-btn--active={searchOpen} onclick={toggleSearch} title="Search images">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
           </button>
           <div class="export menu">
-            <button class="export__trigger" onclick={() => { openMenu = openMenu === 'export' ? null : 'export'; }} title="Download images">
+            <button class="export__trigger" onclick={() => { openMenu = openMenu === 'export' ? null : 'export'; }} aria-label="Download images" title="Download images">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="export__icon"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
             </button>
             {#if openMenu === 'export'}

--- a/entrypoints/popup/Images.svelte
+++ b/entrypoints/popup/Images.svelte
@@ -359,8 +359,7 @@
         </div>
         <div class="toolbar__actions">
           <button class="toolbar-btn" class:toolbar-btn--active={highlightOn} onclick={toggleHighlight} title="Highlight images on page">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-            Highlight
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>
           </button>
           <button class="toolbar-btn" class:toolbar-btn--active={searchOpen} onclick={toggleSearch} title="Search images">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
@@ -368,8 +367,6 @@
           <div class="export menu">
             <button class="export__trigger" onclick={() => { openMenu = openMenu === 'export' ? null : 'export'; }} title="Download images">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="export__icon"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-              Export
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="export__chevron"><path d="M6 9l6 6 6-6"/></svg>
             </button>
             {#if openMenu === 'export'}
               <div class="export__menu">
@@ -532,7 +529,6 @@
   .export__trigger { display: flex; align-items: center; gap: 4px; padding: 0 8px; height: 28px; border-radius: 6px; border: 1px solid var(--border-strong); background: var(--bg); font-family: inherit; font-size: 11px; font-weight: 600; color: var(--text-muted); cursor: pointer; transition: all 0.12s; }
   .export__trigger:hover { border-color: var(--border-hover); color: var(--text-secondary); }
   .export__icon { width: 13px; height: 13px; flex-shrink: 0; stroke-width: 1.8; }
-  .export__chevron { width: 10px; height: 10px; stroke-width: 2; opacity: 0.6; }
   .export__menu { position: absolute; top: calc(100% + 4px); right: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: var(--shadow-pop); z-index: 10; min-width: 150px; padding: 4px; }
   .export__item { display: flex; align-items: center; justify-content: space-between; width: 100%; padding: 6px 10px; border: none; background: none; font-family: inherit; font-size: 12px; cursor: pointer; border-radius: 5px; transition: background 0.1s; }
   .export__item:hover { background: var(--bg-hover); }

--- a/entrypoints/popup/Links.svelte
+++ b/entrypoints/popup/Links.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-  import type { LinkKind, RawLink } from './utils/types';
+  import type { LinkKind, RawLink, LinkStatusResult } from './utils/types';
   import { followRank, isDofollow } from './utils/links';
   import { csvField } from './utils/format';
   import SummaryBar from './SummaryBar.svelte';
   import type { SummaryItem } from './SummaryBar.svelte';
-  import { highlightLinks, scrollToLink } from './utils/utils';
+  import { highlightLinks, scrollToLink, checkLinkStatus } from './utils/utils';
   import { trackAction } from '@/utils/analytics';
   import { untrack, onDestroy } from 'svelte';
+  import { SvelteMap } from 'svelte/reactivity';
 
   let { links, domain }: { links: RawLink[]; domain: string | null } = $props();
 
@@ -24,12 +25,13 @@
   let typeFilter = $state('all');
   let followFilter = $state('all');
   let anchorFilter = $state('all');
+  let statusFilter = $state('all');
   let showHidden = $state(true);
   let search = $state('');
   let searchOpen = $state(false);
-  let openMenu = $state<'type' | 'follow' | 'anchor' | 'export' | null>(null);
+  let openMenu = $state<'type' | 'follow' | 'anchor' | 'status' | 'export' | null>(null);
 
-  type SortKey = 'index' | 'url' | 'follow' | 'type';
+  type SortKey = 'index' | 'url' | 'follow' | 'type' | 'status';
   let sortKey = $state<SortKey>('index');
   let sortDir = $state<'asc' | 'desc'>('asc');
 
@@ -37,6 +39,61 @@
   let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
   let highlightOn = $state(false);
   let searchInput = $state<HTMLInputElement | null>(null);
+
+  // On-demand HTTP status, keyed by href so duplicate links share one result.
+  const statuses = new SvelteMap<string, LinkStatusResult>();
+  let checking = $state(false);
+  let checkDone = $state(0);
+  let checkTotal = $state(0);
+  let checkRun = 0; // bumped to cancel an in-flight sweep (unmount or re-run)
+
+  // HEAD-first checks minimise side effects, but auto-firing every link could
+  // still hit side-effecting GET endpoints, so this stays an explicit action.
+  async function checkStatuses() {
+    if (checking) return;
+    const urls = [...new Set(links.filter(l => l.kind === 'internal' || l.kind === 'external').map(l => l.href))];
+    if (urls.length === 0) return;
+    const run = ++checkRun;
+    checking = true;
+    checkTotal = urls.length;
+    checkDone = 0;
+    trackAction('links_check_status', { count: urls.length });
+
+    let next = 0;
+    const worker = async () => {
+      while (next < urls.length && run === checkRun) {
+        const url = urls[next++];
+        const res = await checkLinkStatus(url);
+        if (run !== checkRun) return;
+        statuses.set(url, res);
+        checkDone++;
+        // Most links share one origin, so back-to-back bursts trip rate limits.
+        // Space requests out with jitter; correctness matters more than speed here.
+        if (next < urls.length) await new Promise((r) => setTimeout(r, 180 + Math.random() * 160));
+      }
+    };
+    // Low concurrency on purpose: 4 connections to a single host is polite enough
+    // to avoid 429s on Cloudflare-fronted stores while still finishing quickly.
+    const pool = Math.min(4, urls.length);
+    await Promise.all(Array.from({ length: pool }, worker));
+    if (run === checkRun) checking = false;
+  }
+
+  function statusLabel(s: LinkStatusResult): string {
+    if (s.bucket === 'redirect') return s.status > 0 ? String(s.status) : '3xx';
+    if (s.bucket === 'error') return 'err';
+    return String(s.status);
+  }
+
+  function statusTitle(s: LinkStatusResult): string {
+    switch (s.bucket) {
+      case 'ok': return `HTTP ${s.status} OK`;
+      case 'redirect': return 'Redirects (3xx) — exact code is not exposed to extensions';
+      case 'client-error': return `HTTP ${s.status} — client error`;
+      case 'server-error': return `HTTP ${s.status} — server error`;
+      default: return 'Unreachable, blocked, or timed out (may differ for a real visitor)';
+    }
+  }
 
   function toggleSearch() {
     searchOpen = !searchOpen;
@@ -56,6 +113,7 @@
   const stats = $derived.by(() => {
     let internal = 0, external = 0, other = 0, dofollow = 0, nofollow = 0, sponsored = 0, ugc = 0,
       image = 0, text = 0, none = 0, hidden = 0;
+    let statusOk = 0, statusRedirect = 0, statusFailing = 0;
     const counts: Record<string, number> = {};
     for (const l of links) {
       if (l.kind === 'internal') internal++; else if (l.kind === 'external') external++; else other++;
@@ -67,8 +125,14 @@
       if (l.text !== '') text++; else none++;
       if (l.isHidden) hidden++;
       counts[l.href] = (counts[l.href] ?? 0) + 1;
+      const st = statuses.get(l.href);
+      if (st) {
+        if (st.bucket === 'ok') statusOk++;
+        else if (st.bucket === 'redirect') statusRedirect++;
+        else statusFailing++;
+      }
     }
-    return { total: links.length, internal, external, other, dofollow, nofollow, sponsored, ugc, image, text, none, hidden, hrefCounts: counts };
+    return { total: links.length, internal, external, other, dofollow, nofollow, sponsored, ugc, image, text, none, hidden, statusOk, statusRedirect, statusFailing, hrefCounts: counts };
   });
 
   // Lowercased searchable text per link, built once per list (not per keystroke).
@@ -87,6 +151,12 @@
       if (anchorFilter === 'text' && link.text === '') return false;
       if (anchorFilter === 'image' && !link.isImage) return false;
       if (anchorFilter === 'none' && link.text !== '') return false;
+      if (statusFilter !== 'all') {
+        const bucket = statuses.get(link.href)?.bucket;
+        if (statusFilter === 'failing') {
+          if (bucket !== 'client-error' && bucket !== 'server-error' && bucket !== 'error') return false;
+        } else if (bucket !== statusFilter) return false;
+      }
       if (!showHidden && link.isHidden) return false;
       if (q && !(haystacks.get(link.index) ?? '').includes(q)) return false;
       return true;
@@ -95,14 +165,28 @@
 
   const KIND_RANK: Record<LinkKind, number> = { internal: 0, external: 1, mailto: 2, tel: 3, other: 4 };
 
+  // Worst-first when ascending, so a status sort surfaces problems. Unchecked
+  // and non-http links (no result) sort to the end.
+  const STATUS_RANK: Record<LinkStatusResult['bucket'], number> = { error: 0, 'server-error': 1, 'client-error': 2, redirect: 3, ok: 4 };
+  const statusRank = (l: RawLink) => {
+    const b = statuses.get(l.href)?.bucket;
+    return b ? STATUS_RANK[b] : 5;
+  };
+
   // Summary of the current view, mirroring the Assets and Images tabs.
   const summaryItems = $derived.by(() => {
     let external = 0, nofollowish = 0, insecure = 0, broken = 0;
+    let httpRedirect = 0, httpDead = 0;
     for (const l of filtered) {
       if (l.kind === 'external') external++;
       if (!isDofollow(l)) nofollowish++;
       if (l.isInsecure) insecure++;
       if (l.isBrokenAnchor) broken++;
+      const st = statuses.get(l.href);
+      if (st) {
+        if (st.bucket === 'redirect') httpRedirect++;
+        else if (st.bucket === 'client-error' || st.bucket === 'server-error' || st.bucket === 'error') httpDead++;
+      }
     }
     const items: SummaryItem[] = [
       { text: `${filtered.length} ${filtered.length === 1 ? 'link' : 'links'}` },
@@ -111,6 +195,8 @@
     if (nofollowish > 0) items.push({ text: `${nofollowish} nofollow`, title: 'Links carrying nofollow, sponsored, or ugc hints' });
     if (insecure > 0) items.push({ text: `${insecure} insecure http`, tone: 'warn' });
     if (broken > 0) items.push({ text: `${broken} broken #`, tone: 'err' });
+    if (httpRedirect > 0) items.push({ text: `${httpRedirect} redirect`, tone: 'warn', title: 'Links that respond with a 3xx redirect' });
+    if (httpDead > 0) items.push({ text: `${httpDead} failing`, tone: 'err', title: 'Links returning 4xx/5xx or unreachable (advisory)' });
     return items;
   });
 
@@ -122,6 +208,7 @@
         case 'url': cmp = a.href.localeCompare(b.href); break;
         case 'follow': cmp = followRank(a) - followRank(b); break;
         case 'type': cmp = KIND_RANK[a.kind] - KIND_RANK[b.kind]; break;
+        case 'status': cmp = statusRank(a) - statusRank(b); break;
         default: cmp = a.index - b.index;
       }
       if (cmp !== 0) return cmp * dir;
@@ -180,6 +267,7 @@
   onDestroy(() => {
     if (highlightOn) highlightLinks(false);
     if (copyResetTimer) clearTimeout(copyResetTimer);
+    checkRun++; // stop any in-flight status sweep
   });
 
   function handleRowClick(e: MouseEvent, index: number) {
@@ -266,17 +354,28 @@
     { value: 'image', label: 'Image', count: stats.image },
     { value: 'none', label: 'None', count: stats.none },
   ]);
+  // The Status facet only appears once a check has run, so its counts reflect
+  // resolved links rather than dangling zeros.
+  const hasChecked = $derived(statuses.size > 0);
+  const statusOptions = $derived([
+    { value: 'all', label: 'All', count: stats.statusOk + stats.statusRedirect + stats.statusFailing },
+    { value: 'ok', label: 'OK', count: stats.statusOk },
+    { value: 'redirect', label: 'Redirect', count: stats.statusRedirect },
+    { value: 'failing', label: 'Failing', count: stats.statusFailing },
+  ]);
 
-  const anyFilterActive = $derived(typeFilter !== 'all' || followFilter !== 'all' || anchorFilter !== 'all' || !showHidden || search.length > 0);
+  const anyFilterActive = $derived(typeFilter !== 'all' || followFilter !== 'all' || anchorFilter !== 'all' || statusFilter !== 'all' || !showHidden || search.length > 0);
 
   function setType(v: string) { typeFilter = v; openMenu = null; trackAction('links_filter', { facet: 'type', value: v }); }
   function setFollow(v: string) { followFilter = v; openMenu = null; trackAction('links_filter', { facet: 'follow', value: v }); }
   function setAnchor(v: string) { anchorFilter = v; openMenu = null; trackAction('links_filter', { facet: 'anchor', value: v }); }
+  function setStatus(v: string) { statusFilter = v; openMenu = null; trackAction('links_filter', { facet: 'status', value: v }); }
 
   function resetFilters() {
     typeFilter = 'all';
     followFilter = 'all';
     anchorFilter = 'all';
+    statusFilter = 'all';
     showHidden = true;
     search = '';
     searchOpen = false;
@@ -294,7 +393,7 @@
   </div>
 {:else}
   <div class="links-tab">
-    {#snippet facet(name: string, key: 'type' | 'follow' | 'anchor', options: { value: string; label: string; count: number }[], selected: string, onSelect: (v: string) => void)}
+    {#snippet facet(name: string, key: 'type' | 'follow' | 'anchor' | 'status', options: { value: string; label: string; count: number }[], selected: string, onSelect: (v: string) => void)}
       <div class="dropdown menu">
         <button class="dropdown__trigger" class:dropdown__trigger--active={selected !== 'all'} onclick={() => { openMenu = openMenu === key ? null : key; }}>
           {selected === 'all' ? name : (options.find(o => o.value === selected)?.label ?? name)}
@@ -331,6 +430,9 @@
           {@render facet('Type', 'type', typeOptions, typeFilter, setType)}
           {@render facet('Follow', 'follow', followOptions, followFilter, setFollow)}
           {@render facet('Anchor', 'anchor', anchorOptions, anchorFilter, setAnchor)}
+          {#if hasChecked}
+            {@render facet('Status', 'status', statusOptions, statusFilter, setStatus)}
+          {/if}
           {#if anyFilterActive}
             <button class="reset-btn" onclick={resetFilters} title="Reset all filters">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
@@ -345,8 +447,7 @@
             </button>
           {/if}
           <button class="toolbar-btn" class:toolbar-btn--active={highlightOn} onclick={toggleHighlight} title="Highlight links on page">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-            Highlight
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>
           </button>
           <button class="toolbar-btn" class:toolbar-btn--active={searchOpen} onclick={toggleSearch} title="Search links">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
@@ -354,8 +455,6 @@
           <div class="export menu">
             <button class="export__trigger" onclick={() => { openMenu = openMenu === 'export' ? null : 'export'; }} title="Download links">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="export__icon"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-              Export
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="export__chevron"><path d="M6 9l6 6 6-6"/></svg>
             </button>
             {#if openMenu === 'export'}
               <div class="export__menu">
@@ -403,6 +502,14 @@
             <th class="th th--url"><button class="th-btn" class:th-btn--active={sortKey === 'url'} onclick={() => toggleSort('url')} title="Sort by URL">Target URL{@render sortIcon('url')}</button> <span class="th__count">({filtered.length}/{stats.total})</span></th>
             <th class="th th--follow"><button class="th-btn" class:th-btn--active={sortKey === 'follow'} onclick={() => toggleSort('follow')} title="Sort by dofollow">Dofollow{@render sortIcon('follow')}</button></th>
             <th class="th th--type"><button class="th-btn" class:th-btn--active={sortKey === 'type'} onclick={() => toggleSort('type')} title="Sort by type">Type{@render sortIcon('type')}</button></th>
+            <th class="th th--status">
+              <span class="check-head">
+                <button class="th-btn" class:th-btn--active={sortKey === 'status'} onclick={() => toggleSort('status')} title="Sort by status">Status{@render sortIcon('status')}</button>
+                <button class="check-action" onclick={checkStatuses} disabled={checking} aria-label="Check link status" title={checking ? `Checking ${checkDone}/${checkTotal}…` : hasChecked ? 'Re-check link status' : 'Check link status (HEAD request, advisory)'}>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" class:spin={checking}><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg>
+                </button>
+              </span>
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -450,6 +557,12 @@
                 {/if}
               </td>
               <td class="td td--type">{kindLabel(link.kind)}</td>
+              <td class="td td--status">
+                {#if statuses.get(link.href)}
+                  {@const st = statuses.get(link.href)!}
+                  <span class="status-pill status-pill--{st.bucket}" title={statusTitle(st)}>{statusLabel(st)}</span>
+                {/if}
+              </td>
             </tr>
           {/each}
         </tbody>
@@ -499,7 +612,6 @@
   .export__trigger { white-space: nowrap; flex-shrink: 0; display: flex; align-items: center; gap: 4px; padding: 0 8px; height: 28px; border-radius: 6px; border: 1px solid var(--border-strong); background: var(--bg); font-family: inherit; font-size: 11px; font-weight: 600; color: var(--text-muted); cursor: pointer; transition: all 0.12s; }
   .export__trigger:hover { border-color: var(--border-hover); color: var(--text-secondary); }
   .export__icon { width: 13px; height: 13px; flex-shrink: 0; stroke-width: 1.8; }
-  .export__chevron { width: 10px; height: 10px; stroke-width: 2; opacity: 0.6; }
   .export__menu { position: absolute; top: calc(100% + 4px); right: 0; background: var(--bg); border: 1px solid var(--border-strong); border-radius: 8px; box-shadow: var(--shadow-pop); z-index: 10; min-width: 150px; padding: 4px; }
   .export__item { display: flex; align-items: center; justify-content: space-between; width: 100%; padding: 6px 10px; border: none; background: none; font-family: inherit; font-size: 12px; cursor: pointer; border-radius: 5px; transition: background 0.1s; }
   .export__item:hover { background: var(--bg-hover); }
@@ -513,6 +625,15 @@
   .toolbar-btn--active { background: var(--btn-bg); color: var(--btn-text); border-color: var(--btn-bg); }
   .toolbar-btn--active:hover { background: var(--btn-bg-hover); border-color: var(--btn-bg-hover); color: var(--btn-text); }
   .toolbar-btn svg { width: 13px; height: 13px; stroke-width: 1.8; flex-shrink: 0; }
+  .spin { animation: spin 0.7s linear infinite; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* Status column header: icon-only check trigger sits after the sortable label */
+  .check-head { display: inline-flex; align-items: center; gap: 6px; }
+  .check-action { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; padding: 0; border: 1px solid var(--border-strong); background: var(--bg); border-radius: 5px; color: var(--text-muted); cursor: pointer; transition: all 0.12s; }
+  .check-action:hover:not(:disabled) { border-color: var(--border-hover); color: var(--accent); }
+  .check-action:disabled { cursor: default; }
+  .check-action svg { width: 12px; height: 12px; stroke-width: 1.9; flex-shrink: 0; }
 
   /* Reset filters */
   .dropdown__trigger, .toolbar-btn, .export__trigger, .reset-btn { box-sizing: border-box; }
@@ -545,6 +666,9 @@
   .th--num { width: 30px; padding-right: 0; }
   .th--follow { width: 76px; }
   .th--type { width: 76px; }
+  /* Combined selectors beat the .th:last-child / .td:last-child gutter so the
+     Check column keeps a balanced inset around its centered button and pill. */
+  .th.th--status, .td.td--status { width: 104px; padding-left: 8px; padding-right: 10px; text-align: center; }
   .th__count { font-weight: 500; color: var(--text-muted); letter-spacing: 0; text-transform: none; }
 
   .th-btn { display: inline-flex; align-items: center; gap: 2px; padding: 0; border: none; background: none; font: inherit; color: inherit; text-transform: inherit; letter-spacing: inherit; cursor: pointer; transition: color 0.12s; }
@@ -570,6 +694,13 @@
   .flag--amber { background: var(--warning-bg); color: var(--warning); }
   .flag--red { background: var(--error-bg); color: var(--error-strong); }
   .hidden-icon { flex-shrink: 0; width: 13px; height: 13px; stroke-width: 1.8; color: var(--text-muted); }
+
+  /* HTTP status pill — monospace digits, color-coded by bucket */
+  .status-pill { flex-shrink: 0; font-family: 'SF Mono', ui-monospace, monospace; font-size: 10px; font-weight: 700; padding: 0 5px; border-radius: 8px; line-height: 16px; }
+  .status-pill--ok { background: var(--success-bg); color: var(--success-strong); }
+  .status-pill--redirect { background: var(--warning-bg); color: var(--warning); }
+  .status-pill--client-error, .status-pill--server-error { background: var(--error-bg); color: var(--error-strong); }
+  .status-pill--error { background: var(--bg-hover); color: var(--text-muted); }
 
   .anchor-row { display: flex; align-items: center; gap: 5px; min-width: 0; margin-top: 1px; }
   .img-tag { flex-shrink: 0; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em; padding: 0 4px; border-radius: 4px; line-height: 14px; background: var(--accent-tint); color: var(--accent); }

--- a/entrypoints/popup/Links.svelte
+++ b/entrypoints/popup/Links.svelte
@@ -58,6 +58,9 @@
     checkDone = 0;
     checkTotal = 0;
     statuses.clear();
+    // The Status facet hides once results are gone, so a lingering status filter
+    // would silently empty the table with no visible control to undo it.
+    statusFilter = 'all';
   });
 
   // HEAD-first checks minimise side effects, but auto-firing every link could
@@ -211,9 +214,10 @@
   // Worst-first when ascending, so a status sort surfaces problems. Unchecked
   // and non-http links (no result) sort to the end.
   const STATUS_RANK: Record<LinkStatusResult['bucket'], number> = { error: 0, 'server-error': 1, 'client-error': 2, redirect: 3, ok: 4 };
+  const UNSCANNED_RANK = 5;
   const statusRank = (l: RawLink) => {
     const b = statuses.get(l.href)?.bucket;
-    return b ? STATUS_RANK[b] : 5;
+    return b ? STATUS_RANK[b] : UNSCANNED_RANK;
   };
 
   // Summary of the current view, mirroring the Assets and Images tabs.
@@ -251,7 +255,13 @@
         case 'url': cmp = a.href.localeCompare(b.href); break;
         case 'follow': cmp = followRank(a) - followRank(b); break;
         case 'type': cmp = KIND_RANK[a.kind] - KIND_RANK[b.kind]; break;
-        case 'status': cmp = statusRank(a) - statusRank(b); break;
+        case 'status': {
+          const ra = statusRank(a), rb = statusRank(b);
+          // Unscanned / non-http rows have no status: keep them last in both directions.
+          if ((ra === UNSCANNED_RANK) !== (rb === UNSCANNED_RANK)) return ra === UNSCANNED_RANK ? 1 : -1;
+          cmp = ra - rb;
+          break;
+        }
         default: cmp = a.index - b.index;
       }
       if (cmp !== 0) return cmp * dir;

--- a/entrypoints/popup/Links.svelte
+++ b/entrypoints/popup/Links.svelte
@@ -64,7 +64,17 @@
   // still hit side-effecting GET endpoints, so this stays an explicit action.
   async function checkStatuses() {
     if (checking) return;
-    const urls = [...new Set(links.filter(l => l.kind === 'internal' || l.kind === 'external').map(l => l.href))];
+    // Fragments are never sent in HTTP requests, so /page#a and /page#b hit the
+    // same resource. Probe each target once and fan the result to every variant.
+    const variantsByTarget = new Map<string, string[]>();
+    for (const l of links) {
+      if (l.kind !== 'internal' && l.kind !== 'external') continue;
+      const target = l.href.split('#')[0]!;
+      const variants = variantsByTarget.get(target);
+      if (variants) variants.push(l.href);
+      else variantsByTarget.set(target, [l.href]);
+    }
+    const urls = [...variantsByTarget.keys()];
     if (urls.length === 0) return;
     const run = ++checkRun;
     checking = true;
@@ -95,7 +105,7 @@
         const url = urls[next++];
         const res = await checkLinkStatus(url);
         if (run !== checkRun) return;
-        pending.push([url, res]);
+        for (const href of variantsByTarget.get(url)!) pending.push([href, res]);
         done++;
         scheduleFlush();
         // Most links share one origin, so back-to-back bursts trip rate limits.

--- a/entrypoints/popup/Links.svelte
+++ b/entrypoints/popup/Links.svelte
@@ -73,12 +73,16 @@
   let checkTotal = $state(0);
   let checkRun = 0; // bumped to cancel an in-flight sweep (unmount or re-run)
 
+  // Serialize the status map only when it actually changes, so high-frequency
+  // filter/search edits below don't re-spread the whole map every keystroke.
+  const statusEntries = $derived([...statuses]);
+
   // Mirror the persisted slice into the per-tab cache whenever it changes (the
   // store debounces the write), so the scan, filters, and sort survive the popup
   // closing and reopening on the same page.
   $effect(() => {
     tabState.saveSection('links', {
-      statuses: [...statuses],
+      statuses: statusEntries,
       typeFilter,
       followFilter,
       anchorFilter,
@@ -90,6 +94,12 @@
       sortKey,
       sortDir
     });
+  });
+
+  // A finished scan is the costly result worth keeping; persist it immediately
+  // (not on the debounce) so closing the popup right after can't drop it.
+  $effect(() => {
+    if (!checking) tabState.flushNow();
   });
 
   // A new page (links prop reassigned) invalidates prior results: cancel any

--- a/entrypoints/popup/Links.svelte
+++ b/entrypoints/popup/Links.svelte
@@ -6,8 +6,9 @@
   import type { SummaryItem } from './SummaryBar.svelte';
   import { highlightLinks, scrollToLink, checkLinkStatus } from './utils/utils';
   import { trackAction } from '@/utils/analytics';
-  import { untrack, onDestroy } from 'svelte';
+  import { untrack, onDestroy, onMount } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
+  import { getTabState } from './stores/tabState.svelte';
 
   let { links, domain }: { links: RawLink[]; domain: string | null } = $props();
 
@@ -22,30 +23,74 @@
     });
   });
 
-  let typeFilter = $state('all');
-  let followFilter = $state('all');
-  let anchorFilter = $state('all');
-  let statusFilter = $state('all');
-  let showHidden = $state(true);
-  let search = $state('');
-  let searchOpen = $state(false);
+  type SortKey = 'index' | 'url' | 'follow' | 'type' | 'status';
+
+  interface LinksPersisted {
+    statuses: [string, LinkStatusResult][];
+    typeFilter: string;
+    followFilter: string;
+    anchorFilter: string;
+    statusFilter: string;
+    showHidden: boolean;
+    search: string;
+    searchOpen: boolean;
+    highlightOn: boolean;
+    sortKey: SortKey;
+    sortDir: 'asc' | 'desc';
+  }
+
+  const tabState = getTabState();
+  const restored = tabState.getSection<LinksPersisted>('links');
+
+  let typeFilter = $state(restored?.typeFilter ?? 'all');
+  let followFilter = $state(restored?.followFilter ?? 'all');
+  let anchorFilter = $state(restored?.anchorFilter ?? 'all');
+  let statusFilter = $state(restored?.statusFilter ?? 'all');
+  let showHidden = $state(restored?.showHidden ?? true);
+  let search = $state(restored?.search ?? '');
+  let searchOpen = $state(restored?.searchOpen ?? false);
   let openMenu = $state<'type' | 'follow' | 'anchor' | 'status' | 'export' | null>(null);
 
-  type SortKey = 'index' | 'url' | 'follow' | 'type' | 'status';
-  let sortKey = $state<SortKey>('index');
-  let sortDir = $state<'asc' | 'desc'>('asc');
+  let sortKey = $state<SortKey>(restored?.sortKey ?? 'index');
+  let sortDir = $state<'asc' | 'desc'>(restored?.sortDir ?? 'asc');
 
   let copied = $state(false);
   let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
-  let highlightOn = $state(false);
+  let highlightOn = $state(restored?.highlightOn ?? false);
   let searchInput = $state<HTMLInputElement | null>(null);
 
+  // onDestroy strips the on-page outlines when the popup closes, so re-apply them
+  // if the restored state had highlighting on.
+  onMount(() => {
+    if (highlightOn) highlightLinks(true);
+  });
+
   // On-demand HTTP status, keyed by href so duplicate links share one result.
-  const statuses = new SvelteMap<string, LinkStatusResult>();
+  // Seeded from the per-tab cache so a prior scan survives reopening the popup.
+  const statuses = new SvelteMap<string, LinkStatusResult>(restored?.statuses ?? []);
   let checking = $state(false);
   let checkDone = $state(0);
   let checkTotal = $state(0);
   let checkRun = 0; // bumped to cancel an in-flight sweep (unmount or re-run)
+
+  // Mirror the persisted slice into the per-tab cache whenever it changes (the
+  // store debounces the write), so the scan, filters, and sort survive the popup
+  // closing and reopening on the same page.
+  $effect(() => {
+    tabState.saveSection('links', {
+      statuses: [...statuses],
+      typeFilter,
+      followFilter,
+      anchorFilter,
+      statusFilter,
+      showHidden,
+      search,
+      searchOpen,
+      highlightOn,
+      sortKey,
+      sortDir
+    });
+  });
 
   // A new page (links prop reassigned) invalidates prior results: cancel any
   // in-flight sweep and clear the map so stale statuses can't color new rows.

--- a/entrypoints/popup/Links.svelte
+++ b/entrypoints/popup/Links.svelte
@@ -47,6 +47,19 @@
   let checkTotal = $state(0);
   let checkRun = 0; // bumped to cancel an in-flight sweep (unmount or re-run)
 
+  // A new page (links prop reassigned) invalidates prior results: cancel any
+  // in-flight sweep and clear the map so stale statuses can't color new rows.
+  let trackedLinks = links;
+  $effect(() => {
+    if (links === trackedLinks) return;
+    trackedLinks = links;
+    checkRun++;
+    checking = false;
+    checkDone = 0;
+    checkTotal = 0;
+    statuses.clear();
+  });
+
   // HEAD-first checks minimise side effects, but auto-firing every link could
   // still hit side-effecting GET endpoints, so this stays an explicit action.
   async function checkStatuses() {
@@ -59,14 +72,32 @@
     checkDone = 0;
     trackAction('links_check_status', { count: urls.length });
 
+    // Batch results into the SvelteMap on a timer rather than per-result: the
+    // stats/summary/sorted deriveds each scan all links, so writing once per
+    // result is O(n^2) on large pages. Flushing periodically caps recomputes.
+    const pending: Array<[string, LinkStatusResult]> = [];
+    let done = 0;
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    const flush = () => {
+      flushTimer = null;
+      if (run !== checkRun) return;
+      for (const [url, res] of pending) statuses.set(url, res);
+      pending.length = 0;
+      checkDone = done;
+    };
+    const scheduleFlush = () => {
+      if (flushTimer === null) flushTimer = setTimeout(flush, 150);
+    };
+
     let next = 0;
     const worker = async () => {
       while (next < urls.length && run === checkRun) {
         const url = urls[next++];
         const res = await checkLinkStatus(url);
         if (run !== checkRun) return;
-        statuses.set(url, res);
-        checkDone++;
+        pending.push([url, res]);
+        done++;
+        scheduleFlush();
         // Most links share one origin, so back-to-back bursts trip rate limits.
         // Space requests out with jitter; correctness matters more than speed here.
         if (next < urls.length) await new Promise((r) => setTimeout(r, 180 + Math.random() * 160));
@@ -76,6 +107,8 @@
     // to avoid 429s on Cloudflare-fronted stores while still finishing quickly.
     const pool = Math.min(4, urls.length);
     await Promise.all(Array.from({ length: pool }, worker));
+    if (flushTimer !== null) clearTimeout(flushTimer);
+    flush();
     if (run === checkRun) checking = false;
   }
 
@@ -446,14 +479,14 @@
               {stats.hidden}
             </button>
           {/if}
-          <button class="toolbar-btn" class:toolbar-btn--active={highlightOn} onclick={toggleHighlight} title="Highlight links on page">
+          <button class="toolbar-btn" class:toolbar-btn--active={highlightOn} onclick={toggleHighlight} aria-label="Highlight links on page" title="Highlight links on page">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>
           </button>
           <button class="toolbar-btn" class:toolbar-btn--active={searchOpen} onclick={toggleSearch} title="Search links">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
           </button>
           <div class="export menu">
-            <button class="export__trigger" onclick={() => { openMenu = openMenu === 'export' ? null : 'export'; }} title="Download links">
+            <button class="export__trigger" onclick={() => { openMenu = openMenu === 'export' ? null : 'export'; }} aria-label="Download links" title="Download links">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" class="export__icon"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
             </button>
             {#if openMenu === 'export'}
@@ -514,6 +547,7 @@
         </thead>
         <tbody>
           {#each sorted as link, i (link.index)}
+            {@const status = statuses.get(link.href)}
             <tr class="row" class:row--hidden={link.isHidden} onclick={(e) => handleRowClick(e, link.index)} title={link.isHidden ? 'Hidden via CSS' : 'Click to scroll to this link'}>
               <td class="td td--num">{i + 1}</td>
               <td class="td td--url">
@@ -558,9 +592,8 @@
               </td>
               <td class="td td--type">{kindLabel(link.kind)}</td>
               <td class="td td--status">
-                {#if statuses.get(link.href)}
-                  {@const st = statuses.get(link.href)!}
-                  <span class="status-pill status-pill--{st.bucket}" title={statusTitle(st)}>{statusLabel(st)}</span>
+                {#if status}
+                  <span class="status-pill status-pill--{status.bucket}" title={statusTitle(status)}>{statusLabel(status)}</span>
                 {/if}
               </td>
             </tr>
@@ -667,7 +700,7 @@
   .th--follow { width: 76px; }
   .th--type { width: 76px; }
   /* Combined selectors beat the .th:last-child / .td:last-child gutter so the
-     Check column keeps a balanced inset around its centered button and pill. */
+     Status column keeps a balanced inset around its centered button and pill. */
   .th.th--status, .td.td--status { width: 104px; padding-left: 8px; padding-right: 10px; text-align: center; }
   .th__count { font-weight: 500; color: var(--text-muted); letter-spacing: 0; text-transform: none; }
 

--- a/entrypoints/popup/Links.svelte
+++ b/entrypoints/popup/Links.svelte
@@ -395,29 +395,35 @@
   }
 
   function exportCsv() {
-    const header = 'URL,Anchor Text,Type,Dofollow,Rel,Is Image,Is Hidden,Insecure HTTP,Broken Anchor';
-    const rows = links.map(l =>
-      [l.href, l.text, l.kind, isDofollow(l), l.rel, l.isImage, l.isHidden, l.isInsecure, l.isBrokenAnchor]
+    const header = 'URL,Anchor Text,Type,Dofollow,Rel,Is Image,Is Hidden,Insecure HTTP,Broken Anchor,Status Code,Status';
+    const rows = links.map(l => {
+      const st = statuses.get(l.href);
+      return [l.href, l.text, l.kind, isDofollow(l), l.rel, l.isImage, l.isHidden, l.isInsecure, l.isBrokenAnchor, st && st.status > 0 ? st.status : '', st?.bucket ?? '']
         .map(csvField)
-        .join(',')
-    );
+        .join(',');
+    });
     downloadFile([header, ...rows].join('\n'), `alfred-links-${siteSlug}.csv`, 'text/csv');
     trackAction('links_export', { format: 'csv', link_count: links.length });
     openMenu = null;
   }
 
   function exportJson() {
-    const data = links.map(l => ({
-      url: l.href,
-      anchorText: l.text,
-      type: l.kind,
-      dofollow: isDofollow(l),
-      rel: l.rel,
-      isImage: l.isImage,
-      isHidden: l.isHidden,
-      isInsecure: l.isInsecure,
-      isBrokenAnchor: l.isBrokenAnchor,
-    }));
+    const data = links.map(l => {
+      const st = statuses.get(l.href);
+      return {
+        url: l.href,
+        anchorText: l.text,
+        type: l.kind,
+        dofollow: isDofollow(l),
+        rel: l.rel,
+        isImage: l.isImage,
+        isHidden: l.isHidden,
+        isInsecure: l.isInsecure,
+        isBrokenAnchor: l.isBrokenAnchor,
+        statusCode: st && st.status > 0 ? st.status : null,
+        status: st?.bucket ?? null,
+      };
+    });
     downloadFile(JSON.stringify(data, null, 2), `alfred-links-${siteSlug}.json`, 'application/json');
     trackAction('links_export', { format: 'json', link_count: links.length });
     openMenu = null;

--- a/entrypoints/popup/Schema.svelte
+++ b/entrypoints/popup/Schema.svelte
@@ -147,14 +147,14 @@
     <div class="toolbar">
       <span class="toolbar__hint">JSON-LD structured data</span>
       <div class="toolbar__actions">
-        <button class="toolbar-btn" onclick={copyAll} title={copied ? 'Copied!' : 'Copy all JSON-LD'}>
+        <button class="toolbar-btn" onclick={copyAll} aria-label="Copy all JSON-LD" title={copied ? 'Copied!' : 'Copy all JSON-LD'}>
           {#if copied}
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><polyline points="20 6 9 17 4 12"/></svg>
           {:else}
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
           {/if}
         </button>
-        <button class="toolbar-btn" onclick={exportJson} title="Download JSON-LD">
+        <button class="toolbar-btn" onclick={exportJson} aria-label="Download JSON-LD" title="Download JSON-LD">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         </button>
       </div>

--- a/entrypoints/popup/Schema.svelte
+++ b/entrypoints/popup/Schema.svelte
@@ -5,6 +5,7 @@
   import type { SummaryItem } from './SummaryBar.svelte';
   import { trackAction } from '@/utils/analytics';
   import { untrack, onDestroy } from 'svelte';
+  import { getTabState } from './stores/tabState.svelte';
 
   let { schema, domain }: { schema: RawSchemaBlock[]; domain: string | null } = $props();
 
@@ -12,7 +13,20 @@
 
   const analysis = $derived(analyzeSchema(schema));
 
-  let overrides = $state<Map<number, boolean>>(new Map());
+  interface SchemaPersisted {
+    overrides: [number, boolean][];
+  }
+
+  const tabState = getTabState();
+  const restored = tabState.getSection<SchemaPersisted>('schema');
+
+  // Per-block open/closed overrides; persisted so expanded entities survive the
+  // popup closing and reopening on the same page.
+  let overrides = $state<Map<number, boolean>>(new Map(restored?.overrides ?? []));
+
+  $effect(() => {
+    tabState.saveSection('schema', { overrides: [...overrides] });
+  });
   function isOpen(i: number): boolean {
     return overrides.get(i) ?? i === 0;
   }

--- a/entrypoints/popup/Schema.svelte
+++ b/entrypoints/popup/Schema.svelte
@@ -147,13 +147,15 @@
     <div class="toolbar">
       <span class="toolbar__hint">JSON-LD structured data</span>
       <div class="toolbar__actions">
-        <button class="toolbar-btn" onclick={copyAll} title="Copy all JSON-LD">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
-          {copied ? 'Copied!' : 'Copy'}
+        <button class="toolbar-btn" onclick={copyAll} title={copied ? 'Copied!' : 'Copy all JSON-LD'}>
+          {#if copied}
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><polyline points="20 6 9 17 4 12"/></svg>
+          {:else}
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
+          {/if}
         </button>
         <button class="toolbar-btn" onclick={exportJson} title="Download JSON-LD">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Export
         </button>
       </div>
     </div>

--- a/entrypoints/popup/Theme.svelte
+++ b/entrypoints/popup/Theme.svelte
@@ -3,13 +3,25 @@
   import CopyIcon from './CopyIcon.svelte';
   import Tooltip from './Tooltip.svelte';
   import { untrack } from 'svelte';
+  import { getTabState } from './stores/tabState.svelte';
   import type { StoreInfo } from './utils/types';
 
   let { storeInfo }: { storeInfo: StoreInfo } = $props();
 
+  interface ThemePersisted {
+    disablePreviewBar: boolean;
+  }
+
+  const tabState = getTabState();
+  const restored = tabState.getSection<ThemePersisted>('theme');
+
   let copying = $state(false);
-  let disablePreviewBar = $state(false);
+  let disablePreviewBar = $state(restored?.disablePreviewBar ?? false);
   let tracked = false;
+
+  $effect(() => {
+    tabState.saveSection('theme', { disablePreviewBar });
+  });
 
   $effect(() => {
     if (tracked) return;

--- a/entrypoints/popup/stores/tabState.svelte.ts
+++ b/entrypoints/popup/stores/tabState.svelte.ts
@@ -40,6 +40,16 @@ function scheduleSave() {
 }
 
 /**
+ * Writes the snapshot immediately, cancelling any pending debounce. Use right
+ * after a high-value, low-frequency change (e.g. a completed scan) so it can't be
+ * lost in the debounce window if the popup closes a moment later.
+ */
+function flushNow() {
+  if (saveTimer !== null) clearTimeout(saveTimer);
+  flush();
+}
+
+/**
  * Binds the store to a tab and loads any saved state for it. Restores only when
  * the stored blob matches this URL and schema version; otherwise starts empty.
  * Must be awaited before reading restoredActiveSection or getSection.
@@ -49,6 +59,11 @@ function scheduleSave() {
 async function hydrate(id: number, url: string): Promise<void> {
   tabId = id;
   pageUrl = url;
+  // Start clean so a second hydrate or a reused popup context (e.g. side panel)
+  // can't carry a prior tab/URL's state forward.
+  sectionData = {};
+  activeSection = null;
+  restoredActiveSection = null;
   // Best-effort flush when the popup is dismissed, so the final state isn't lost
   // inside the debounce window (e.g. clicking a link right after a scan).
   if (!pagehideBound && typeof window !== 'undefined') {
@@ -105,6 +120,7 @@ export function getTabState() {
     getSection,
     saveSection,
     setActiveSection,
+    flushNow,
     get restoredActiveSection() {
       return restoredActiveSection;
     }

--- a/entrypoints/popup/stores/tabState.svelte.ts
+++ b/entrypoints/popup/stores/tabState.svelte.ts
@@ -1,0 +1,112 @@
+import { storage } from '#imports';
+import { SCHEMA_VERSION, keyFor, isFreshFor, type PersistedBlob, type PopupSection } from './tabState';
+
+/**
+ * Per-browser-tab popup state, persisted to session storage so a view survives
+ * the popup closing. The record is keyed by tab id and stamped with the page
+ * URL: it is restored only on the same tab + same URL, deleted when the tab
+ * closes (see the tabs.onRemoved listener in the background), and naturally gone
+ * on browser restart (session area). Any storage failure degrades to in-memory.
+ */
+
+export type { PopupSection } from './tabState';
+
+const SAVE_DEBOUNCE_MS = 250;
+
+let tabId: number | null = null;
+let pageUrl: string | null = null;
+let restoredActiveSection: PopupSection | null = null;
+
+// Latest serialized value per section plus the active section, flushed to
+// storage on a debounce. Plain (non-reactive) state: components own the reactive
+// copies and push snapshots in via saveSection / setActiveSection.
+let sectionData: Record<string, unknown> = {};
+let activeSection: PopupSection | null = null;
+
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+let pagehideBound = false;
+
+/** Writes the current snapshot to session storage; no-op until hydrate() runs. */
+function flush() {
+  saveTimer = null;
+  if (tabId === null || pageUrl === null) return;
+  const blob: PersistedBlob = { v: SCHEMA_VERSION, url: pageUrl, activeSection, sections: sectionData };
+  storage.setItem(keyFor(tabId), blob).catch(() => {});
+}
+
+/** Coalesces bursts of changes (e.g. a streaming scan) into one debounced write. */
+function scheduleSave() {
+  if (saveTimer === null) saveTimer = setTimeout(flush, SAVE_DEBOUNCE_MS);
+}
+
+/**
+ * Binds the store to a tab and loads any saved state for it. Restores only when
+ * the stored blob matches this URL and schema version; otherwise starts empty.
+ * Must be awaited before reading restoredActiveSection or getSection.
+ * @param id - The active tab's id, used as the storage key.
+ * @param url - The current page URL; a mismatch discards stale state.
+ */
+async function hydrate(id: number, url: string): Promise<void> {
+  tabId = id;
+  pageUrl = url;
+  // Best-effort flush when the popup is dismissed, so the final state isn't lost
+  // inside the debounce window (e.g. clicking a link right after a scan).
+  if (!pagehideBound && typeof window !== 'undefined') {
+    window.addEventListener('pagehide', flush);
+    pagehideBound = true;
+  }
+  try {
+    const blob = await storage.getItem<PersistedBlob>(keyFor(id));
+    if (isFreshFor(blob, url)) {
+      sectionData = { ...blob.sections };
+      activeSection = blob.activeSection;
+      restoredActiveSection = blob.activeSection;
+    }
+  } catch {
+    // Storage unavailable: run in-memory only.
+  }
+}
+
+/**
+ * Returns the restored slice a section saved under `name`, or undefined if none
+ * was restored. Components use it to seed their initial reactive state.
+ * @param name - The section's slice key (e.g. 'links').
+ */
+function getSection<T>(name: string): T | undefined {
+  return sectionData[name] as T | undefined;
+}
+
+/**
+ * Stores a section's serialized snapshot and schedules a debounced write. Call
+ * from a reactive effect so the snapshot tracks the section's state.
+ * @param name - The section's slice key (e.g. 'links').
+ * @param value - A JSON-serializable snapshot of the section's persisted state.
+ */
+function saveSection(name: string, value: unknown): void {
+  sectionData[name] = value;
+  scheduleSave();
+}
+
+/**
+ * Records the currently open popup section and schedules a save. Ignores
+ * no-op writes so re-applying the restored section doesn't trigger a write.
+ * @param section - The active tab/section in the popup.
+ */
+function setActiveSection(section: PopupSection): void {
+  if (section === activeSection) return;
+  activeSection = section;
+  scheduleSave();
+}
+
+/** Accessor for the per-tab state store's public surface. */
+export function getTabState() {
+  return {
+    hydrate,
+    getSection,
+    saveSection,
+    setActiveSection,
+    get restoredActiveSection() {
+      return restoredActiveSection;
+    }
+  };
+}

--- a/entrypoints/popup/stores/tabState.ts
+++ b/entrypoints/popup/stores/tabState.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure schema + validation for per-tab popup state. Kept free of runes and WXT
+ * auto-imports so it can be unit-tested directly; the reactive/storage glue lives
+ * in tabState.svelte.ts.
+ */
+
+export type PopupSection = 'theme' | 'headings' | 'links' | 'assets' | 'images' | 'schema' | 'settings';
+
+export const SCHEMA_VERSION = 1;
+
+export const keyFor = (tabId: number) => `session:popupTabState:${tabId}` as const;
+
+export interface PersistedBlob {
+  v: number;
+  url: string;
+  activeSection: PopupSection | null;
+  sections: Record<string, unknown>;
+}
+
+/**
+ * Whether a stored blob may hydrate the current view: it must match the schema
+ * version and belong to the URL currently open (a different URL means the tab
+ * navigated, which busts everything).
+ */
+export function isFreshFor(blob: unknown, url: string): blob is PersistedBlob {
+  if (!blob || typeof blob !== 'object') return false;
+  const b = blob as Partial<PersistedBlob>;
+  return b.v === SCHEMA_VERSION && b.url === url && typeof b.sections === 'object' && b.sections !== null;
+}

--- a/entrypoints/popup/tests/linkStatus.test.ts
+++ b/entrypoints/popup/tests/linkStatus.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import { bucketFor, retryAfterMs } from '../../background/linkStatus';
+
+const headers = (retryAfter?: string) =>
+  new Response(null, retryAfter === undefined ? {} : { headers: { 'Retry-After': retryAfter } });
+
+describe('bucketFor', () => {
+  it('maps 2xx to ok at both boundaries', () => {
+    expect(bucketFor(200)).toBe('ok');
+    expect(bucketFor(299)).toBe('ok');
+  });
+
+  it('maps 3xx to redirect at both boundaries', () => {
+    expect(bucketFor(300)).toBe('redirect');
+    expect(bucketFor(399)).toBe('redirect');
+  });
+
+  it('maps 4xx to client-error at both boundaries', () => {
+    expect(bucketFor(400)).toBe('client-error');
+    expect(bucketFor(404)).toBe('client-error');
+    expect(bucketFor(499)).toBe('client-error');
+  });
+
+  it('maps 5xx to server-error', () => {
+    expect(bucketFor(500)).toBe('server-error');
+    expect(bucketFor(503)).toBe('server-error');
+    expect(bucketFor(600)).toBe('server-error');
+  });
+
+  it('treats sub-200 and 0 (no status) as error', () => {
+    expect(bucketFor(199)).toBe('error');
+    expect(bucketFor(0)).toBe('error');
+  });
+});
+
+describe('retryAfterMs', () => {
+  it('parses a Retry-After given in seconds', () => {
+    expect(retryAfterMs(headers('5'))).toBe(5000);
+  });
+
+  it('defaults to 2000ms when the header is missing', () => {
+    expect(retryAfterMs(headers())).toBe(2000);
+  });
+
+  it('defaults to 2000ms when the header is unparseable', () => {
+    expect(retryAfterMs(headers('soon'))).toBe(2000);
+  });
+
+  it('clamps a negative delay to 0', () => {
+    expect(retryAfterMs(headers('-5'))).toBe(0);
+  });
+
+  it('clamps an over-large delay to the 8000ms cap', () => {
+    expect(retryAfterMs(headers('999'))).toBe(8000);
+  });
+
+  it('handles an HTTP-date in the past as 0', () => {
+    expect(retryAfterMs(headers('Wed, 01 Jan 2020 00:00:00 GMT'))).toBe(0);
+  });
+
+  it('clamps a far-future HTTP-date to the 8000ms cap', () => {
+    expect(retryAfterMs(headers('Wed, 01 Jan 2031 00:00:00 GMT'))).toBe(8000);
+  });
+});

--- a/entrypoints/popup/tests/tabState.test.ts
+++ b/entrypoints/popup/tests/tabState.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import { isFreshFor, SCHEMA_VERSION, keyFor } from '../stores/tabState';
+
+const blob = (over: Record<string, unknown> = {}) => ({
+  v: SCHEMA_VERSION,
+  url: 'https://example.com/page',
+  activeSection: 'links',
+  sections: { links: {} },
+  ...over
+});
+
+describe('isFreshFor', () => {
+  it('accepts a current-version blob for the same URL', () => {
+    expect(isFreshFor(blob(), 'https://example.com/page')).toBe(true);
+  });
+
+  it('rejects a blob whose URL differs (tab navigated away)', () => {
+    expect(isFreshFor(blob(), 'https://example.com/other')).toBe(false);
+  });
+
+  it('rejects a blob from an older schema version', () => {
+    expect(isFreshFor(blob({ v: SCHEMA_VERSION - 1 }), 'https://example.com/page')).toBe(false);
+  });
+
+  it('rejects a blob missing its sections object', () => {
+    expect(isFreshFor(blob({ sections: undefined }), 'https://example.com/page')).toBe(false);
+    expect(isFreshFor(blob({ sections: null }), 'https://example.com/page')).toBe(false);
+  });
+
+  it('rejects null, undefined, and non-objects', () => {
+    expect(isFreshFor(null, 'https://example.com/page')).toBe(false);
+    expect(isFreshFor(undefined, 'https://example.com/page')).toBe(false);
+    expect(isFreshFor('nope', 'https://example.com/page')).toBe(false);
+  });
+});
+
+describe('keyFor', () => {
+  it('namespaces the record per tab id under the session area', () => {
+    expect(keyFor(42)).toBe('session:popupTabState:42');
+  });
+});

--- a/entrypoints/popup/utils/types.ts
+++ b/entrypoints/popup/utils/types.ts
@@ -34,8 +34,6 @@ export type LinkStatusBucket =
 export interface LinkStatusResult {
   status: number; // numeric HTTP code, 0 when unknown (redirect/error)
   bucket: LinkStatusBucket;
-  redirected: boolean;
-  finalUrl?: string; // resolved URL after following redirects (when known)
 }
 
 export type AssetKind = 'script' | 'style';

--- a/entrypoints/popup/utils/types.ts
+++ b/entrypoints/popup/utils/types.ts
@@ -21,6 +21,23 @@ export interface RawLink {
   isBrokenAnchor: boolean; // same-page #fragment with no matching id/name on the page
 }
 
+// Outcome of an on-demand HTTP status check for a link's href. Buckets exist
+// because fetch cannot read a redirect's exact code (manual redirects come back
+// opaque), and network/blocked failures carry no status at all.
+export type LinkStatusBucket =
+  | 'ok' // 2xx
+  | 'redirect' // 3xx (exact code unknowable via fetch)
+  | 'client-error' // 4xx
+  | 'server-error' // 5xx
+  | 'error'; // network failure, blocked, or timeout
+
+export interface LinkStatusResult {
+  status: number; // numeric HTTP code, 0 when unknown (redirect/error)
+  bucket: LinkStatusBucket;
+  redirected: boolean;
+  finalUrl?: string; // resolved URL after following redirects (when known)
+}
+
 export type AssetKind = 'script' | 'style';
 export type AssetLoad = 'async' | 'defer' | 'blocking' | 'inline';
 export type AssetPlacement = 'head' | 'body' | 'footer';

--- a/entrypoints/popup/utils/utils.ts
+++ b/entrypoints/popup/utils/utils.ts
@@ -19,9 +19,9 @@ import { lookupThemeStoreEntry } from './themeStoreLookup';
 export const checkLinkStatus = async (url: string): Promise<LinkStatusResult> => {
   try {
     const res = await browser.runtime.sendMessage({ action: 'check_link_status', url });
-    return res ?? { status: 0, bucket: 'error', redirected: false };
+    return res ?? { status: 0, bucket: 'error' };
   } catch {
-    return { status: 0, bucket: 'error', redirected: false };
+    return { status: 0, bucket: 'error' };
   }
 };
 

--- a/entrypoints/popup/utils/utils.ts
+++ b/entrypoints/popup/utils/utils.ts
@@ -1,5 +1,29 @@
-import type { StoreInfo, Theme, RawHeading, RawLink, RawAsset, RawImage, RawSchemaBlock } from './types';
+import type {
+  StoreInfo,
+  Theme,
+  RawHeading,
+  RawLink,
+  RawAsset,
+  RawImage,
+  RawSchemaBlock,
+  LinkStatusResult
+} from './types';
 import { lookupThemeStoreEntry } from './themeStoreLookup';
+
+/**
+ * Asks the background service worker to resolve a link's HTTP status. The check
+ * runs there so it survives the popup closing and can read cross-origin codes.
+ * @param {string} url - Absolute http(s) URL to check.
+ * @returns {Promise<LinkStatusResult>} Status bucket; 'error' if unreachable.
+ */
+export const checkLinkStatus = async (url: string): Promise<LinkStatusResult> => {
+  try {
+    const res = await browser.runtime.sendMessage({ action: 'check_link_status', url });
+    return res ?? { status: 0, bucket: 'error', redirected: false };
+  } catch {
+    return { status: 0, bucket: 'error', redirected: false };
+  }
+};
 
 /**
  * Extracts all H1-H6 headings from the active tab via content script.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.06.23",
+  "version": "2026.06.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "2026.06.22",
+  "version": "2026.06.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/supabase/functions/track/index.ts
+++ b/supabase/functions/track/index.ts
@@ -63,6 +63,7 @@ const VALID_ACTIONS = [
   'links_copy',
   'links_sort',
   'links_toggle_hidden',
+  'links_check_status',
   'assets_view',
   'assets_filter',
   'assets_export',

--- a/test-pages/README.md
+++ b/test-pages/README.md
@@ -43,6 +43,13 @@ test-pages/
 - Folders named `static/` or `fixtures/` hold supporting files and are not
   listed in the index (no `.html` inside them).
 
+## HTTP status fixtures
+
+The Links tab's status checker needs endpoints that return arbitrary status
+codes. `GET /status/<n>` responds with HTTP status `<n>` (e.g. `/status/404`,
+`/status/500`). For 3xx codes it sets a `Location` header (`?to=<url>`, or `/`
+by default) so the popup's `redirect: 'manual'` probe sees a real redirect.
+
 ## robots.txt scenarios
 
 `/robots.txt` is origin-wide, so one static file can't cover multiple cases.

--- a/test-pages/README.md
+++ b/test-pages/README.md
@@ -26,7 +26,7 @@ For a step-by-step checklist of the current branch's changes, see
 test-pages/
   server.ts        tiny node:http static server (run with bun)
   headings/        one page per heading-analysis scenario (positive + negative)
-  links/           link extraction scenarios
+  links/           link extraction and status-check scenarios
   images/          image extraction/audit scenarios (+ static/ fixtures)
   assets/          script/stylesheet scenarios (+ static/ js & css fixtures)
   theme/           fake Shopify storefront (sets window.Shopify + window.__st)

--- a/test-pages/TESTING.md
+++ b/test-pages/TESTING.md
@@ -9,7 +9,7 @@ Work top to bottom; every step says which page to open and what to look for.
 
 1. Run the automated suite first. It covers the analyzers, link
    classification, asset classification, and image classification logic
-   (154 tests):
+   (212 tests):
 
    ```sh
    bun test

--- a/test-pages/links/no-links.html
+++ b/test-pages/links/no-links.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Empty state: a page with no anchors at all</title>
+    <style>
+      body {
+        font:
+          15px/1.7 system-ui,
+          sans-serif;
+        margin: 0;
+        background: #fff;
+        color: #222;
+      }
+      .expected {
+        background: #eef4ff;
+        border: 1px solid #c7d8f7;
+        border-radius: 8px;
+        margin: 16px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+      .expected .t {
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .expected ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      main {
+        max-width: 680px;
+        margin: 24px auto 48px;
+        padding: 0 16px;
+      }
+      .back {
+        display: inline-block;
+        margin: 0 16px 24px;
+        font: inherit;
+        font-size: 13px;
+        background: none;
+        border: none;
+        color: #5c6ac4;
+        cursor: pointer;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <aside class="expected">
+      <div class="t">Expected — Links tab</div>
+      <ul>
+        <li>Empty state: link icon plus "No links found on this page" — no toolbar, table, or summary bar</li>
+        <li>
+          This page deliberately has zero <code>&lt;a href&gt;</code> elements, so the back nav is a button, not a link
+          (an anchor would make the count 1 and defeat the empty state)
+        </li>
+      </ul>
+    </aside>
+    <main>
+      <p>This page contains text content but no anchors, to exercise the Links tab's empty state.</p>
+    </main>
+    <button class="back" onclick="location.href = '/'">← all test pages</button>
+  </body>
+</html>

--- a/test-pages/links/status-check.html
+++ b/test-pages/links/status-check.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Status column: 2xx / 3xx / 4xx / 5xx / rate-limit / unreachable</title>
+    <style>
+      body {
+        font:
+          15px/1.7 system-ui,
+          sans-serif;
+        margin: 0;
+        background: #fff;
+        color: #222;
+      }
+      .expected {
+        background: #eef4ff;
+        border: 1px solid #c7d8f7;
+        border-radius: 8px;
+        margin: 16px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+      .expected .t {
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .expected ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      main {
+        max-width: 680px;
+        margin: 24px auto 48px;
+        padding: 0 16px;
+      }
+      main li {
+        margin-bottom: 6px;
+      }
+      .back {
+        display: inline-block;
+        margin: 0 16px 24px;
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <aside class="expected">
+      <div class="t">Expected — Links tab, Status column</div>
+      <ul>
+        <li>
+          9 links total (the 8 below plus the "← all test pages" nav link, which also resolves 200). Status is opt-in:
+          click the check button in the "Status" column header to run it.
+        </li>
+        <li>
+          The sweep is throttled (4 at a time, jittered) and takes a few seconds; the 429 row adds a ~2s backoff before
+          resolving. Pills fill in live as each link resolves.
+        </li>
+        <li>Green <b>200</b>: rows 1, 2, and the nav link</li>
+        <li>Amber redirect <b>3xx</b>: rows 3 (301) and 4 (308) — the exact code is not exposed to extensions</li>
+        <li>Red <b>404</b> (row 5) and red <b>500</b> (row 6)</li>
+        <li>
+          Red <b>429</b> (row 7): the background backs off once, then reports the still-rate-limited code rather than
+          hiding it
+        </li>
+        <li>Grey <b>err</b> (row 8): external <code>.invalid</code> host that never resolves</li>
+        <li>
+          Duplicate <code>/status/200</code> (rows 1–2) is fetched once and shares the result; a ×2 dup badge shows
+        </li>
+        <li>
+          A "Status" filter facet appears after the sweep: OK ×3, Redirect ×2, Failing ×4 (404, 500, 429, unreachable).
+          "Failing" isolates the broken set.
+        </li>
+        <li>Sorting by the "Status" header surfaces worst-first: err → 500 → 404/429 → redirects → 200</li>
+        <li>Summary bar gains "2 redirect" (amber) and "4 failing" (red); 0 insecure (localhost is loopback)</li>
+      </ul>
+    </aside>
+    <main id="top">
+      <ul>
+        <li><a href="/status/200">1. 200 OK</a></li>
+        <li><a href="/status/200">2. 200 OK again (duplicate href, checked once)</a></li>
+        <li><a href="/status/301?to=/links/mixed.html">3. 301 redirect (to a real page)</a></li>
+        <li><a href="/status/308?to=/links/mixed.html">4. 308 permanent redirect</a></li>
+        <li><a href="/status/404">5. 404 Not Found</a></li>
+        <li><a href="/status/500">6. 500 Internal Server Error</a></li>
+        <li><a href="/status/429">7. 429 Too Many Requests (exercises backoff)</a></li>
+        <li><a href="https://nonexistent.invalid/">8. Unreachable external host (DNS failure → err)</a></li>
+      </ul>
+    </main>
+    <a class="back" href="/">← all test pages</a>
+  </body>
+</html>

--- a/test-pages/server.ts
+++ b/test-pages/server.ts
@@ -11,6 +11,9 @@
  *                    same-origin fetch from /robots/<scenario>.html carries that
  *                    page as referer: 'missing' → 404, 'server-error' → 500,
  *                    anything else → robots/fixtures/<scenario>.robots.txt.
+ * - GET /status/<n>  responds with HTTP status <n>, for the Links status-check
+ *                    fixtures. 3xx codes carry a Location (?to=… or /) so the
+ *                    popup's redirect:'manual' probe sees a real redirect.
  * - everything else  static files from this directory
  */
 import { createServer } from 'node:http';
@@ -105,6 +108,16 @@ const server = createServer(async (req, res) => {
       const { status, type, body } = await robotsResponse(req.headers.referer);
       res.writeHead(status, { 'content-type': type });
       res.end(body);
+      return;
+    }
+
+    const statusMatch = url.pathname.match(/^\/status\/(\d{3})$/);
+    if (statusMatch) {
+      const code = Number(statusMatch[1]);
+      const headers: Record<string, string> = { 'content-type': 'text/plain; charset=utf-8' };
+      if (code >= 300 && code < 400) headers['location'] = url.searchParams.get('to') ?? '/';
+      res.writeHead(code, headers);
+      res.end(`status ${code}`);
       return;
     }
 

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -63,6 +63,7 @@ export type AnalyticsAction =
   | 'links_copy'
   | 'links_sort'
   | 'links_toggle_hidden'
+  | 'links_check_status'
   | 'assets_view'
   | 'assets_filter'
   | 'assets_export'
@@ -149,6 +150,7 @@ const TIME_SAVINGS: Record<AnalyticsAction, number | ((metadata?: Record<string,
   links_copy: 60,
   links_sort: 25,
   links_toggle_hidden: 5,
+  links_check_status: (metadata) => Number(metadata?.count ?? 0) * 5 + 15,
   assets_view: 60,
   assets_filter: 25,
   assets_export: 60,
@@ -252,6 +254,7 @@ const ACTION_CATEGORIES: Record<AnalyticsAction, string> = {
   links_copy: 'SEO',
   links_sort: 'SEO',
   links_toggle_hidden: 'SEO',
+  links_check_status: 'SEO',
   assets_view: 'SEO',
   assets_filter: 'SEO',
   assets_export: 'SEO',

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     name: 'Alfred - Shopify Theme Detector',
     description:
       'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.06.23',
+    version: '2026.06.24',
     action: {
       default_title: 'Alfred'
     },

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     name: 'Alfred - Shopify Theme Detector',
     description:
       'Instantly detect themes on any Shopify store. Streamline your workflow with smart shortcuts and Shopify productivity tools.',
-    version: '2026.06.22',
+    version: '2026.06.23',
     action: {
       default_title: 'Alfred'
     },


### PR DESCRIPTION
## Summary

Ships two features for the popup, released together as **v2026.06.24**.

**Link Status Checker (Links tab)**
- New sortable **Status** column with an icon **check** button that probes every internal/external link from the background service worker (HEAD-first, GET fallback on 403/404/405/501, `redirect: 'manual'`, `cache: 'no-store'`, `credentials: 'include'`, per-probe 8s timeout, one 429/503 backoff honoring `Retry-After`).
- Results bucketed into color-coded pills: `ok` (2xx), `redirect` (3xx), `client-error` (4xx), `server-error` (5xx), `error` (unreachable). Throttled 4-worker sweep with jitter, batched 150ms flush, fragment-URL dedup, cancel-on-unmount.
- Status filter facet (All/OK/Redirect/Failing), worst-first status sort, summary-bar tallies.
- Icon-only toolbar actions standardized across Links/Images/Assets/Schema/Headings.

**Per-tab popup state persistence (new)**
- General `tabState` layer (`entrypoints/popup/stores/tabState.{ts,svelte.ts}`): persists popup view state to `chrome.storage.session` keyed by tab id, restored on reopen, busted on navigation (URL stamp) and tab close (`tabs.onRemoved`).
- Wired into the active section (App.svelte) + all six tabs: Links (scan results, filters, sort, search, highlight), Images (filters/sort/search/highlight), Assets (filters/sort/search/expanded rows), Schema (expanded entities), Headings (`showHidden`), Theme (`disablePreviewBar`).
- Pure schema/validation (`isFreshFor`, `keyFor`) split into a rune-free `tabState.ts` so the background can reuse `keyFor` and the logic is unit-testable.

## Test Coverage

```
PURE LOGIC (gate-relevant)            COVERED   TEST
--------------------------------------------------------------------
linkStatus.ts  bucketFor / retryAfterMs   [x]   linkStatus.test.ts (boundaries, clamps, HTTP-date)
tabState.ts    isFreshFor / keyFor         [x]   tabState.test.ts (url/version/null/sections)
Pure units: 5/5 = 100%   Branch gaps: 0

GLUE (intentionally uncovered — no DOM/extension harness)
fetch/AbortController, chrome.storage, browser.* messaging, Svelte component reactivity
```

Tests: 212 pass, 0 fail (9 files). Coverage gate: PASS (100% of pure units).

## Pre-Landing Review

5 specialists on the per-tab delta (the link-status portion was reviewed on prior commits). 4 informational findings, all auto-fixed:
- **maintainability:** background hardcoded the `session:popupTabState:<id>` key → now imports `keyFor()` (single source of truth).
- **performance:** Links/Assets persist `$effect` re-spread the full `statuses`/`expanded` collection on every search keystroke → memoized via `$derived`.
- testing / security / design: NO FINDINGS (lifecycle traced clean; no cross-tab bleed; no new CSS).

PR Quality Score: 8.0/10.

## Adversarial Review

Claude subagent + Codex adversarial + Codex structured review (P1 gate). Both adversarial passes converged on one real finding, fixed:
- **Lost-write window:** the `pagehide` flush can't reliably complete (`storage.setItem` is async), so a scan could be lost in the 250ms debounce if the popup closed right after. Fix: `flushNow()` persists immediately the moment a scan completes (the high-value data); plus a defensive state reset in `hydrate()`.
- Codex structured review: **no [P1] — GATE PASS.** Confirmed Chrome + Firefox builds succeed and tabState tests pass.

## Documentation

- **CLAUDE.md**: documented the per-tab view-state store convention (`tabState.svelte.ts`, session-storage backed, URL-stamped, `tabs.onRemoved` cleanup).
- **test-pages/README.md / TESTING.md**: documented the `GET /status/<n>` fixture route; fixed stale test count.

### Documentation debt (non-blocking, flagged by independent review)
- CHANGELOG wording slightly over-sells in a few spots (e.g. "checks every link" — mailto/tel are skipped); left under changelog clobber protection, tighten on next `/version-bump` if desired.
- README Features list omits the SEO popup tabs — pre-existing gap, not introduced here.

## Verification

- `bun test` — 212 pass, 0 fail
- `tsc --noEmit` — clean
- `wxt build` (chrome-mv3 + firefox) — clean (per Codex review)

## Test plan

- [x] Scan links → close popup → reopen on same page → scan + filters + tab restored
- [x] Navigate same tab to new URL → reopen → fresh (default section, no scan)
- [x] Close tab → reopen popup elsewhere → fresh
- [x] Search/highlight/filters/sort restored per tab (Links/Images/Assets/Schema/Headings/Theme)
