### PR TITLE
feat(admin): Activity log sidebar for products and pages

### DIFF
--- a/entrypoints/options/components/settings/AdminSettings.svelte
+++ b/entrypoints/options/components/settings/AdminSettings.svelte
@@ -13,7 +13,8 @@
   const settingsItems: SettingItem[] = [
     { key: 'collapsibleSidebar', label: 'Collapsible sidebar', details: 'Adds a toggle button to collapse/expand the Shopify admin navigation sidebar' },
     { key: 'warnBeforeClosingCodeEditor', label: 'Warn before closing code editor', details: 'Show a confirmation dialog before closing the theme code editor page' },
-    { key: 'themeListUtils', label: 'Theme list utilities', details: 'Adds copy buttons for Theme ID and Preview URL to each theme on the themes list page' }
+    { key: 'themeListUtils', label: 'Theme list utilities', details: 'Adds copy buttons for Theme ID and Preview URL to each theme on the themes list page' },
+    { key: 'editHistory', label: 'Activity log', details: 'Shows a collapsible activity log at the top of the product and page admin sidebar' }
   ];
 
   function handleChange(key: string, e: Event) {

--- a/entrypoints/options/stores/settings.svelte.ts
+++ b/entrypoints/options/stores/settings.svelte.ts
@@ -41,7 +41,8 @@ const defaultSettings: AlfredSettings = {
   admin: {
     collapsibleSidebar: true,
     warnBeforeClosingCodeEditor: true,
-    themeListUtils: true
+    themeListUtils: true,
+    editHistory: true
   }
 };
 

--- a/entrypoints/shopify-admin.content/edit-history.logic.ts
+++ b/entrypoints/shopify-admin.content/edit-history.logic.ts
@@ -1,0 +1,424 @@
+export interface ShopifyEditEvent {
+  id: number;
+  subject_id: number;
+  created_at: string;
+  subject_type: string;
+  verb: string;
+  arguments: unknown[];
+  body: string | null;
+  message: string;
+  author: string;
+  description: string;
+  path: string;
+}
+
+export type DisplayEvent =
+  | { kind: 'single'; event: ShopifyEditEvent }
+  | {
+      kind: 'target-group';
+      events: ShopifyEditEvent[];
+      targets: string[];
+      groupVerb: 'published' | 'unpublished';
+      targetKind: 'market' | 'sales-channel';
+      created_at: string;
+      author: string;
+    };
+
+const MARKET_PUBLISH_RE = /included on ([^:]+):/i;
+const SALES_CHANNEL_PUBLISH_RE = /included (?:a|the) product on ([^:]+):/i;
+const SALES_CHANNEL_UNPUBLISH_RE = /excluded (?:a|the) product from ([^:]+)(?::|\.)/i;
+
+/** Whether the current admin path supports /events.json. */
+export const isEditHistoryPage = (pathname: string): boolean =>
+  /^\/store\/[^/]+\/(products|pages)\/\d+\/?$/.test(pathname) || /^\/admin\/(products|pages)\/\d+\/?$/.test(pathname);
+
+/** Build the events.json URL for the current admin resource page. */
+export const getEventsUrl = (pathname: string, origin: string): string => {
+  const cleanPath = pathname.replace(/\/$/, '');
+  return `${origin}${cleanPath}/events.json`;
+};
+
+export const isMarketPublishEvent = (event: ShopifyEditEvent): boolean =>
+  event.verb === 'published' && MARKET_PUBLISH_RE.test(event.description || event.message);
+
+export const extractMarketName = (event: ShopifyEditEvent): string => {
+  const text = event.description || event.message;
+  return MARKET_PUBLISH_RE.exec(text)?.[1]?.trim() ?? 'Unknown market';
+};
+
+export const isSalesChannelPublishEvent = (event: ShopifyEditEvent): boolean =>
+  event.verb === 'published' &&
+  !isMarketPublishEvent(event) &&
+  SALES_CHANNEL_PUBLISH_RE.test(event.description || event.message);
+
+export const extractSalesChannelName = (event: ShopifyEditEvent): string => {
+  const text = event.description || event.message;
+  return SALES_CHANNEL_PUBLISH_RE.exec(text)?.[1]?.trim() ?? 'Unknown sales channel';
+};
+
+export const isSalesChannelUnpublishEvent = (event: ShopifyEditEvent): boolean =>
+  event.verb === 'unpublished' && SALES_CHANNEL_UNPUBLISH_RE.test(event.description || event.message);
+
+export const extractSalesChannelUnpublishTarget = (event: ShopifyEditEvent): string => {
+  const text = event.description || event.message;
+  return SALES_CHANNEL_UNPUBLISH_RE.exec(text)?.[1]?.trim() ?? 'Unknown sales channel';
+};
+
+type TargetGrouper = {
+  groupVerb: 'published' | 'unpublished';
+  targetKind: 'market' | 'sales-channel';
+  test: (event: ShopifyEditEvent) => boolean;
+  extract: (event: ShopifyEditEvent) => string;
+};
+
+const TARGET_GROUPERS: TargetGrouper[] = [
+  { groupVerb: 'published', targetKind: 'market', test: isMarketPublishEvent, extract: extractMarketName },
+  {
+    groupVerb: 'published',
+    targetKind: 'sales-channel',
+    test: isSalesChannelPublishEvent,
+    extract: extractSalesChannelName
+  },
+  {
+    groupVerb: 'unpublished',
+    targetKind: 'sales-channel',
+    test: isSalesChannelUnpublishEvent,
+    extract: extractSalesChannelUnpublishTarget
+  }
+];
+
+const getTargetGrouper = (event: ShopifyEditEvent): TargetGrouper | null =>
+  TARGET_GROUPERS.find((grouper) => grouper.test(event)) ?? null;
+
+/** Milliseconds since epoch from a Shopify event, or null when missing. */
+export const getEventTimestampMs = (event: ShopifyEditEvent | Record<string, unknown>): number | null => {
+  const record = event as Record<string, unknown>;
+  const candidates: unknown[] = [
+    record.created_at,
+    record.createdAt,
+    (record.attributes as Record<string, unknown> | undefined)?.created_at,
+    (record.attributes as Record<string, unknown> | undefined)?.createdAt
+  ];
+
+  for (const value of candidates) {
+    if (typeof value === 'string' && value.trim()) {
+      const ms = Date.parse(value);
+      if (Number.isFinite(ms)) {
+        return ms;
+      }
+    }
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value < 1e12 ? value * 1000 : value;
+    }
+  }
+
+  return null;
+};
+
+const sameEventTimestamp = (a: ShopifyEditEvent, b: ShopifyEditEvent): boolean => {
+  const aMs = getEventTimestampMs(a);
+  const bMs = getEventTimestampMs(b);
+  return aMs !== null && bMs !== null && aMs === bMs;
+};
+
+/** Comma-separated targets for a grouped publish/unpublish card. */
+export const formatTargetList = (targets: string[], targetKind: 'market' | 'sales-channel'): string =>
+  targetKind === 'market' ? formatMarketList(targets) : targets.join(', ');
+
+/** Description line for a grouped publish/unpublish card. */
+export const formatTargetGroupDescription = (
+  groupVerb: 'published' | 'unpublished',
+  targetKind: 'market' | 'sales-channel',
+  targets: string[]
+): string => {
+  const list = formatTargetList(targets, targetKind);
+  const salesChannelSuffix = targetKind === 'sales-channel' ? ' sales channels' : '';
+
+  if (groupVerb === 'published') {
+    return `Published to ${list}${salesChannelSuffix}`;
+  }
+
+  return `Unpublished from ${list}${salesChannelSuffix}`;
+};
+
+/** @deprecated Use formatTargetList */
+export const formatPublishTargetList = formatTargetList;
+
+const MARKET_FOR_SUFFIX_RE = /^(.+ for )(.+)$/;
+
+/** Compact market names when many share the same prefix (e.g. Managed Markets catalog for XX). */
+export const formatMarketList = (markets: string[]): string => {
+  if (!markets.length) {
+    return '';
+  }
+
+  const prefixCounts = new Map<string, number>();
+  for (const market of markets) {
+    const match = MARKET_FOR_SUFFIX_RE.exec(market);
+    if (match) {
+      prefixCounts.set(match[1]!, (prefixCounts.get(match[1]!) ?? 0) + 1);
+    }
+  }
+
+  const emittedGroups = new Set<string>();
+  const parts: string[] = [];
+
+  for (const market of markets) {
+    const match = MARKET_FOR_SUFFIX_RE.exec(market);
+    if (!match) {
+      parts.push(market);
+      continue;
+    }
+
+    const prefix = match[1]!;
+    const count = prefixCounts.get(prefix) ?? 0;
+
+    if (count < 2) {
+      parts.push(market);
+      continue;
+    }
+
+    if (emittedGroups.has(prefix)) {
+      continue;
+    }
+
+    emittedGroups.add(prefix);
+    const suffixes = markets.flatMap((name) => {
+      const suffixMatch = MARKET_FOR_SUFFIX_RE.exec(name);
+      return suffixMatch?.[1] === prefix ? [suffixMatch[2]!] : [];
+    });
+    const groupLabel = prefix.replace(/ for $/, '');
+    parts.push(`${groupLabel} (${suffixes.join(', ')})`);
+  }
+
+  return parts.join(', ');
+};
+
+/** Extra detail for update events — changed field names from arguments. */
+export const getEventDetail = (event: ShopifyEditEvent): string | null => {
+  if (event.verb !== 'update' || !event.arguments?.length) {
+    return null;
+  }
+
+  const fields = event.arguments.filter(
+    (arg, index) => index > 0 && typeof arg === 'string' && arg !== 'api_client_id' && !/^\d+$/.test(arg)
+  );
+
+  return fields.length ? fields.join(', ') : null;
+};
+
+export const VERB_LABELS: Record<string, string> = {
+  create: 'Created',
+  update: 'Updated',
+  published: 'Published',
+  unpublished: 'Unpublished',
+  status_changed: 'Status changed',
+  destroy: 'Deleted',
+  delete: 'Deleted'
+};
+
+/** Human-readable label for an event verb. */
+export const formatVerbLabel = (verb: string): string => {
+  if (VERB_LABELS[verb]) {
+    return VERB_LABELS[verb];
+  }
+
+  return verb
+    .split('_')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
+
+/** CSS modifier class for a verb badge. Underscores are stripped for valid class names. */
+export const getVerbBadgeClass = (verb: string): string =>
+  `alfred-edit-history__badge--${verb.replace(/[^a-z0-9-]/gi, '')}`;
+
+const TRAILING_RESOURCE_SUFFIX = /:\s[^:]+\.?$/;
+
+/** Clean Shopify event descriptions for the activity sidebar. */
+export const formatEventDescription = (description: string): string => {
+  let text = description.trim().replace(TRAILING_RESOURCE_SUFFIX, '').replace(/\.$/, '');
+
+  text = text
+    .replace(/\bcreated a new product\b/gi, 'created the product')
+    .replace(/\bcreated a new page\b/gi, 'created the page')
+    .replace(/\bchanged product status\b/gi, 'changed the product status')
+    .replace(/\bProduct was included on\b/g, 'Included the product on')
+    .replace(/\ba product\b/gi, 'the product')
+    .replace(/\ba page\b/gi, 'the page')
+    .replace(/\bupdated product\b/gi, 'updated the product');
+
+  if (
+    /included the product on\b/i.test(text) &&
+    !/sales channel$/i.test(text) &&
+    !/^Included the product on\b/.test(text)
+  ) {
+    text = `${text} sales channel`;
+  }
+
+  if (/^Included the product on\b/.test(text) && !/market$/i.test(text)) {
+    text = `${text} market`;
+  }
+
+  if (/excluded the product from\b/i.test(text) && !/sales channel$/i.test(text)) {
+    text = `${text} sales channel`;
+  }
+
+  return text;
+};
+
+/** Whether the event was performed by Shopify (system), not a staff member. */
+export const isShopifyAuthor = (author: string): boolean => author.trim().toLowerCase() === 'shopify';
+
+/** Show newest events first while preserving Shopify's tie order. */
+export const eventsForDisplay = (events: ShopifyEditEvent[]): ShopifyEditEvent[] => {
+  if (events.length < 2) {
+    return [...events];
+  }
+
+  const copy = [...events];
+  const first = copy[0]!;
+  const last = copy[copy.length - 1]!;
+  const firstTime = getEventTimestampMs(first) ?? 0;
+  const lastTime = getEventTimestampMs(last) ?? 0;
+
+  const isNewestFirst = firstTime > lastTime || (firstTime === lastTime && first.id > last.id);
+
+  return isNewestFirst ? copy : copy.toReversed();
+};
+
+/** Collapse same-timestamp publish/unpublish events into one row. */
+export const groupEditEvents = (events: ShopifyEditEvent[]): DisplayEvent[] => {
+  const result: DisplayEvent[] = [];
+  let index = 0;
+
+  while (index < events.length) {
+    const event = events[index];
+    if (!event) {
+      index += 1;
+      continue;
+    }
+
+    const grouper = getTargetGrouper(event);
+    if (!grouper) {
+      result.push({ kind: 'single', event });
+      index += 1;
+      continue;
+    }
+
+    const group: ShopifyEditEvent[] = [event];
+    index += 1;
+
+    while (index < events.length) {
+      const next = events[index];
+      if (!next || !grouper.test(next) || !sameEventTimestamp(group[group.length - 1]!, next)) {
+        break;
+      }
+      group.push(next);
+      index += 1;
+    }
+
+    if (group.length === 1) {
+      result.push({ kind: 'single', event: group[0]! });
+      continue;
+    }
+
+    result.push({
+      kind: 'target-group',
+      events: group,
+      targets: group.map(grouper.extract),
+      groupVerb: grouper.groupVerb,
+      targetKind: grouper.targetKind,
+      created_at: group[0]!.created_at,
+      author: group[0]!.author
+    });
+  }
+
+  return result;
+};
+
+const coerceString = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+const readField = (record: Record<string, unknown>, ...keys: string[]): unknown => {
+  for (const key of keys) {
+    if (key in record) {
+      return record[key];
+    }
+  }
+  return undefined;
+};
+
+const normalizeEvent = (raw: unknown): ShopifyEditEvent | null => {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const record = raw as Record<string, unknown>;
+  const nested = record.event && typeof record.event === 'object' ? (record.event as Record<string, unknown>) : record;
+
+  const createdAt = coerceString(
+    readField(nested, 'created_at', 'createdAt') ?? readField(record, 'created_at', 'createdAt')
+  );
+
+  return {
+    id: Number(readField(nested, 'id') ?? readField(record, 'id')) || 0,
+    subject_id:
+      Number(readField(nested, 'subject_id', 'subjectId') ?? readField(record, 'subject_id', 'subjectId')) || 0,
+    created_at: createdAt,
+    subject_type: coerceString(
+      readField(nested, 'subject_type', 'subjectType') ?? readField(record, 'subject_type', 'subjectType')
+    ),
+    verb: coerceString(readField(nested, 'verb') ?? readField(record, 'verb')),
+    arguments: Array.isArray(nested.arguments)
+      ? nested.arguments
+      : Array.isArray(record.arguments)
+        ? record.arguments
+        : [],
+    body: (readField(nested, 'body') ?? readField(record, 'body') ?? null) as string | null,
+    message: coerceString(readField(nested, 'message') ?? readField(record, 'message')),
+    author: coerceString(readField(nested, 'author') ?? readField(record, 'author')),
+    description: coerceString(readField(nested, 'description') ?? readField(record, 'description')),
+    path: coerceString(readField(nested, 'path') ?? readField(record, 'path'))
+  };
+};
+
+/** Local clock time HH:MM:SS for an event timestamp. */
+export const formatEventClockTime = (event: ShopifyEditEvent | Record<string, unknown>): string => {
+  const timestampMs = getEventTimestampMs(event);
+  if (timestampMs === null) {
+    return '';
+  }
+
+  const date = new Date(timestampMs);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${hours}:${minutes}:${seconds}`;
+};
+
+export const parseEventsResponse = (payload: unknown): ShopifyEditEvent[] => {
+  let rawEvents: unknown[] = [];
+
+  if (Array.isArray(payload)) {
+    rawEvents = payload;
+  } else if (payload && typeof payload === 'object' && Array.isArray((payload as { events?: unknown }).events)) {
+    rawEvents = (payload as { events: unknown[] }).events;
+  }
+
+  return rawEvents.map(normalizeEvent).filter((event): event is ShopifyEditEvent => event !== null);
+};
+
+export const getDisplaySubjectType = (events: DisplayEvent[]): string | undefined => {
+  const first = events[0];
+  if (!first) {
+    return undefined;
+  }
+
+  return first.kind === 'single' ? first.event.subject_type : first.events[0]?.subject_type;
+};

--- a/entrypoints/shopify-admin.content/edit-history.util.ts
+++ b/entrypoints/shopify-admin.content/edit-history.util.ts
@@ -1,0 +1,450 @@
+import { getItem } from '~/utils/storage';
+import { formatTimeAgo } from '~/utils/helpers';
+import { sendTrackEvent } from '~/utils/analytics';
+import {
+  getDisplaySubjectType,
+  getEventDetail,
+  getEventsUrl,
+  getEventTimestampMs,
+  getVerbBadgeClass,
+  groupEditEvents,
+  isEditHistoryPage,
+  parseEventsResponse,
+  eventsForDisplay,
+  formatEventClockTime,
+  formatEventDescription,
+  formatTargetGroupDescription,
+  formatVerbLabel,
+  isShopifyAuthor,
+  type DisplayEvent,
+  type ShopifyEditEvent
+} from './edit-history.logic';
+
+export {
+  extractMarketName,
+  formatEventClockTime,
+  formatVerbLabel,
+  getEventDetail,
+  getEventTimestampMs,
+  getEventsUrl,
+  getVerbBadgeClass,
+  groupEditEvents,
+  isEditHistoryPage,
+  isMarketPublishEvent,
+  isSalesChannelUnpublishEvent,
+  isShopifyAuthor,
+  parseEventsResponse,
+  eventsForDisplay,
+  formatEventDescription,
+  formatMarketList,
+  formatTargetGroupDescription,
+  formatTargetList,
+  formatPublishTargetList,
+  type DisplayEvent,
+  type ShopifyEditEvent
+} from './edit-history.logic';
+
+const ROOT_ATTR = 'data-alfred-edit-history';
+const STYLE_ID = 'alfred-edit-history-styles-v2';
+
+const formatTimestamp = (event: ShopifyEditEvent): string => formatTimeAgo(getEventTimestampMs(event) ?? Number.NaN);
+
+const createTextEl = (tag: string, className: string, text: string): HTMLElement => {
+  const element = document.createElement(tag);
+  element.className = className;
+  element.textContent = text;
+  return element;
+};
+
+const itemClass = (author: string): string =>
+  `alfred-edit-history__item${isShopifyAuthor(author) ? ' alfred-edit-history__item--shopify' : ''}`;
+
+const appendAuthorMeta = (parent: HTMLElement, event: ShopifyEditEvent): void => {
+  const time = formatEventClockTime(event);
+  const label = time ? `${event.author} • ${time}` : event.author;
+  parent.append(createTextEl('p', 'alfred-edit-history__meta', label));
+};
+
+const createEventListItem = (display: DisplayEvent): HTMLLIElement => {
+  const li = document.createElement('li');
+
+  if (display.kind === 'target-group') {
+    const anchor = display.events[0]!;
+    li.className = itemClass(display.author);
+
+    const row = document.createElement('div');
+    row.className = 'alfred-edit-history__row';
+    row.append(
+      createTextEl(
+        'span',
+        `alfred-edit-history__badge ${getVerbBadgeClass(display.groupVerb)}`,
+        formatVerbLabel(display.groupVerb)
+      ),
+      createTextEl('span', 'alfred-edit-history__time', formatTimestamp(anchor))
+    );
+    li.append(row);
+
+    li.append(
+      createTextEl(
+        'p',
+        'alfred-edit-history__description',
+        formatTargetGroupDescription(display.groupVerb, display.targetKind, display.targets)
+      )
+    );
+    appendAuthorMeta(li, anchor);
+    return li;
+  }
+
+  const { event } = display;
+  li.className = itemClass(event.author);
+
+  const row = document.createElement('div');
+  row.className = 'alfred-edit-history__row';
+  row.append(
+    createTextEl('span', `alfred-edit-history__badge ${getVerbBadgeClass(event.verb)}`, formatVerbLabel(event.verb)),
+    createTextEl('span', 'alfred-edit-history__time', formatTimestamp(event))
+  );
+  li.append(row);
+
+  li.append(createTextEl('p', 'alfred-edit-history__description', formatEventDescription(event.description)));
+
+  const detail = getEventDetail(event);
+  if (detail) {
+    li.append(createTextEl('p', 'alfred-edit-history__detail', detail));
+  }
+
+  appendAuthorMeta(li, event);
+  return li;
+};
+
+const setBodyStatus = (container: HTMLElement, text: string): HTMLElement => {
+  container.replaceChildren();
+  const status = document.createElement('p');
+  status.className = 'alfred-edit-history__status';
+  status.textContent = text;
+  container.append(status);
+  return status;
+};
+
+const ensureStyles = (): void => {
+  document.getElementById('alfred-edit-history-styles')?.remove();
+
+  let style = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+  if (!style) {
+    style = document.createElement('style');
+    style.id = STYLE_ID;
+    document.head.appendChild(style);
+  }
+
+  style.textContent = `
+    [${ROOT_ATTR}] {
+      margin-bottom: 16px;
+    }
+
+    .alfred-edit-history__card {
+      border: 1px solid var(--p-color-border, #e3e3e3);
+      border-radius: 12px;
+      background: var(--p-color-bg-surface, #fff);
+      overflow: hidden;
+    }
+
+    .alfred-edit-history__summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 12px 14px;
+      cursor: pointer;
+      list-style: none;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--p-color-text, #303030);
+    }
+
+    .alfred-edit-history__summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .alfred-edit-history__summary::after {
+      content: '';
+      width: 8px;
+      height: 8px;
+      border-right: 2px solid var(--p-color-icon-secondary, #8a8a8a);
+      border-bottom: 2px solid var(--p-color-icon-secondary, #8a8a8a);
+      transform: rotate(45deg);
+      transition: transform 0.15s ease;
+      flex-shrink: 0;
+    }
+
+    .alfred-edit-history__card[open] .alfred-edit-history__summary::after {
+      transform: rotate(-135deg);
+      margin-top: 4px;
+    }
+
+    .alfred-edit-history__body {
+      border-top: 1px solid var(--p-color-border, #e3e3e3);
+      padding: 10px 14px 14px;
+    }
+
+    .alfred-edit-history__status {
+      margin: 0;
+      font-size: 12px;
+      color: var(--p-color-text-secondary, #616161);
+    }
+
+    .alfred-edit-history__list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .alfred-edit-history__item {
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--p-color-border-secondary, #ebebeb);
+    }
+
+    [${ROOT_ATTR}] .alfred-edit-history__item--shopify {
+      margin: 0 -8px;
+      padding: 10px 8px 12px;
+      border-bottom: none;
+      border-radius: 8px;
+      background-color: #fff6ee;
+      box-shadow: inset 3px 0 0 #ffd6a4;
+    }
+
+    .alfred-edit-history__item:last-child {
+      padding-bottom: 0;
+      border-bottom: none;
+    }
+
+    .alfred-edit-history__row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      margin-bottom: 4px;
+    }
+
+    .alfred-edit-history__badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 600;
+      line-height: 1.4;
+      background: var(--p-color-bg-surface-secondary, #f3f3f3);
+      color: var(--p-color-text, #303030);
+    }
+
+    .alfred-edit-history__badge--create {
+      background: #e3f1df;
+      color: #014b40;
+    }
+
+    .alfred-edit-history__badge--update {
+      background: #eaf4ff;
+      color: #003d7a;
+    }
+
+    .alfred-edit-history__badge--published {
+      background: #f4f0ff;
+      color: #4a0082;
+    }
+
+    .alfred-edit-history__badge--unpublished {
+      background: #fff1e3;
+      color: #7a4300;
+    }
+
+    .alfred-edit-history__badge--statuschanged {
+      background: #eef3ff;
+      color: #1f5199;
+    }
+
+    .alfred-edit-history__badge--destroy,
+    .alfred-edit-history__badge--delete {
+      background: #feecec;
+      color: #8e0b21;
+    }
+
+    .alfred-edit-history__time {
+      font-size: 11px;
+      color: var(--p-color-text-secondary, #616161);
+      white-space: nowrap;
+    }
+
+    .alfred-edit-history__description {
+      margin: 0;
+      font-size: 12px;
+      line-height: 1.45;
+      color: var(--p-color-text, #303030);
+    }
+
+    .alfred-edit-history__detail {
+      margin: 4px 0 0;
+      font-size: 11px;
+      line-height: 1.4;
+      color: var(--p-color-text-secondary, #616161);
+    }
+
+    .alfred-edit-history__meta {
+      margin: 4px 0 0;
+      font-size: 11px;
+      color: var(--p-color-text-secondary, #616161);
+    }
+  `;
+};
+
+const findSidebarAnchor = (): HTMLElement | null => {
+  const sections = document.querySelectorAll<HTMLElement>(
+    '.Polaris-Layout__Section--oneThird, [class*="Layout__Section--oneThird"]'
+  );
+
+  for (const section of sections) {
+    if (/Status|Publishing|Theme template|Product organization/i.test(section.textContent ?? '')) {
+      return section;
+    }
+  }
+
+  return sections[0] ?? null;
+};
+
+const createActivityRoot = (): { root: HTMLElement; body: HTMLElement; details: HTMLDetailsElement } | null => {
+  const root = document.createElement('div');
+  root.setAttribute(ROOT_ATTR, 'true');
+
+  const details = document.createElement('details');
+  details.className = 'alfred-edit-history__card';
+
+  const summary = document.createElement('summary');
+  summary.className = 'alfred-edit-history__summary';
+  summary.textContent = 'Activity';
+
+  const body = document.createElement('div');
+  body.className = 'alfred-edit-history__body';
+
+  const status = document.createElement('p');
+  status.className = 'alfred-edit-history__status';
+  status.textContent = 'Expand to load activity.';
+
+  body.append(status);
+  details.append(summary, body);
+  root.append(details);
+
+  return { root, body, details };
+};
+
+const loadEvents = async (container: HTMLElement): Promise<void> => {
+  ensureStyles();
+  const status = setBodyStatus(container, 'Loading activity…');
+
+  try {
+    const response = await fetch(getEventsUrl(window.location.pathname, window.location.origin), {
+      credentials: 'include'
+    });
+
+    if (!response.ok) {
+      status.textContent = response.status === 404 ? 'No activity found.' : 'Could not load activity.';
+      return;
+    }
+
+    const events = groupEditEvents(eventsForDisplay(parseEventsResponse(await response.json())));
+
+    if (!events.length) {
+      status.textContent = 'No activity recorded yet.';
+      return;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'alfred-edit-history__list';
+    for (const display of events) {
+      list.append(createEventListItem(display));
+    }
+    status.replaceWith(list);
+
+    sendTrackEvent('edit_history_view', {
+      subject_type: getDisplaySubjectType(events),
+      event_count: events.length
+    });
+  } catch (error) {
+    console.error('[alfred] activity log failed', error);
+    status.textContent = 'Could not load activity.';
+  }
+};
+
+const injectEditHistory = (): boolean => {
+  if (!isEditHistoryPage(window.location.pathname)) {
+    document.querySelector(`[${ROOT_ATTR}]`)?.remove();
+    return false;
+  }
+
+  const sidebar = findSidebarAnchor();
+  if (!sidebar) {
+    return false;
+  }
+
+  const existing = document.querySelector(`[${ROOT_ATTR}]`) as HTMLElement | null;
+  if (existing) {
+    const alreadyFirst = existing.parentElement === sidebar && sidebar.firstElementChild === existing;
+    if (!alreadyFirst) {
+      sidebar.prepend(existing);
+    }
+    return true;
+  }
+
+  ensureStyles();
+
+  const created = createActivityRoot();
+  if (!created) {
+    return false;
+  }
+
+  const { root, body, details } = created;
+
+  details.addEventListener('toggle', () => {
+    if (!details.open) {
+      return;
+    }
+
+    sendTrackEvent('edit_history_expand');
+    loadEvents(body);
+  });
+
+  try {
+    sidebar.prepend(root);
+  } catch {
+    return false;
+  }
+
+  return true;
+};
+
+/** Inject activity log card on product/page admin pages. */
+export const setupEditHistory = async (): Promise<void> => {
+  const settings = await getItem<AlfredSettings>('settings');
+  if (settings?.admin?.editHistory === false) {
+    return;
+  }
+
+  let currentPath = window.location.pathname;
+  injectEditHistory();
+
+  let debounceTimer: ReturnType<typeof setTimeout>;
+  const observer = new MutationObserver(() => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      if (window.location.pathname !== currentPath) {
+        document.querySelector(`[${ROOT_ATTR}]`)?.remove();
+        currentPath = window.location.pathname;
+      }
+
+      injectEditHistory();
+    }, 250);
+  });
+
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+};

--- a/entrypoints/shopify-admin.content/index.ts
+++ b/entrypoints/shopify-admin.content/index.ts
@@ -1,4 +1,5 @@
 import { setupToggleSidebar } from './ToggleSidebar';
+import { setupEditHistory } from './edit-history.util';
 import { getItem } from '~/utils/storage';
 
 export default defineContentScript({
@@ -6,6 +7,7 @@ export default defineContentScript({
   runAt: 'document_end',
   async main() {
     setupToggleSidebar();
+    setupEditHistory();
 
     /**
      * Warn before closing the theme code editor page.

--- a/entrypoints/shopify-admin.content/tests/edit-history.test.ts
+++ b/entrypoints/shopify-admin.content/tests/edit-history.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  extractMarketName,
+  extractSalesChannelName,
+  extractSalesChannelUnpublishTarget,
+  formatEventClockTime,
+  formatTargetGroupDescription,
+  formatTargetList,
+  formatVerbLabel,
+  getEventDetail,
+  getEventTimestampMs,
+  getEventsUrl,
+  getVerbBadgeClass,
+  groupEditEvents,
+  isEditHistoryPage,
+  isMarketPublishEvent,
+  isSalesChannelPublishEvent,
+  isSalesChannelUnpublishEvent,
+  eventsForDisplay,
+  formatEventDescription,
+  formatMarketList,
+  isShopifyAuthor,
+  parseEventsResponse,
+  type ShopifyEditEvent
+} from '../edit-history.logic';
+
+const productSuffix = 'Kärcher Foam Jet Nozzle with Mixing Regulator and Directional Nozzle (600ml Bottle)';
+
+const salesChannelUnpublishEvent = (channel: string, createdAt: string, id: number): ShopifyEditEvent => ({
+  id,
+  subject_id: 1,
+  created_at: createdAt,
+  subject_type: 'Product',
+  verb: 'unpublished',
+  arguments: ['Product name'],
+  body: null,
+  message: `Liz Ayers excluded the product from ${channel}: ${productSuffix}.`,
+  author: 'Liz Ayers',
+  description: `Liz Ayers excluded the product from ${channel}: ${productSuffix}.`,
+  path: '/admin/products/1'
+});
+
+const salesChannelEvent = (channel: string, createdAt: string, id: number): ShopifyEditEvent => ({
+  id,
+  subject_id: 1,
+  created_at: createdAt,
+  subject_type: 'Product',
+  verb: 'published',
+  arguments: ['Product name'],
+  body: null,
+  message: `Liz Ayers included a product on ${channel}: <a href="#">Product</a>.`,
+  author: 'Liz Ayers',
+  description: `Liz Ayers included a product on ${channel}: Product.`,
+  path: '/admin/products/1'
+});
+
+const marketEvent = (market: string, createdAt: string, id: number): ShopifyEditEvent => ({
+  id,
+  subject_id: 1,
+  created_at: createdAt,
+  subject_type: 'Product',
+  verb: 'published',
+  arguments: ['Product name'],
+  body: null,
+  message: `Product was included on ${market}: <a href="#">Product</a>.`,
+  author: 'Shopify',
+  description: `Product was included on ${market}: Product.`,
+  path: '/admin/products/1'
+});
+
+const baseEvent = (overrides: Partial<ShopifyEditEvent>): ShopifyEditEvent => ({
+  id: 1,
+  subject_id: 1,
+  created_at: '2026-02-19T10:40:57+00:00',
+  subject_type: 'Product',
+  verb: 'create',
+  arguments: ['Product name'],
+  body: null,
+  message: 'Created product',
+  author: 'Jenny Hopper',
+  description: 'Jenny Hopper created a new product: Product.',
+  path: '/admin/products/1',
+  ...overrides
+});
+
+describe('isEditHistoryPage', () => {
+  it('matches admin.shopify.com product and page URLs', () => {
+    expect(isEditHistoryPage('/store/lanoguarduk/products/15568040427904')).toBe(true);
+    expect(isEditHistoryPage('/store/lanoguarduk/pages/123456789')).toBe(true);
+  });
+
+  it('matches legacy myshopify admin URLs', () => {
+    expect(isEditHistoryPage('/admin/products/15568040427904')).toBe(true);
+    expect(isEditHistoryPage('/admin/pages/123456789/')).toBe(true);
+  });
+
+  it('ignores unsupported admin resources', () => {
+    expect(isEditHistoryPage('/store/lanoguarduk/collections/123')).toBe(false);
+    expect(isEditHistoryPage('/store/lanoguarduk/articles/123')).toBe(false);
+    expect(isEditHistoryPage('/store/lanoguarduk/themes')).toBe(false);
+  });
+});
+
+describe('getEventsUrl', () => {
+  it('appends events.json to the current resource path', () => {
+    expect(getEventsUrl('/store/demo/products/123', 'https://admin.shopify.com')).toBe(
+      'https://admin.shopify.com/store/demo/products/123/events.json'
+    );
+  });
+});
+
+describe('eventsForDisplay', () => {
+  it('reverses oldest-first shopify order', () => {
+    const events = [
+      baseEvent({ id: 237571030811008, verb: 'create', created_at: '2025-09-05T13:18:52+01:00' }),
+      baseEvent({ id: 237571031400832, verb: 'status_changed', created_at: '2025-09-05T13:18:52+01:00' })
+    ];
+
+    expect(eventsForDisplay(events).map((event) => event.verb)).toEqual(['status_changed', 'create']);
+  });
+
+  it('keeps newest-first shopify order', () => {
+    const events = [
+      baseEvent({ id: 237571031400832, verb: 'status_changed', created_at: '2025-09-05T13:18:52+01:00' }),
+      baseEvent({ id: 237571030811008, verb: 'create', created_at: '2025-09-05T13:18:52+01:00' })
+    ];
+
+    expect(eventsForDisplay(events).map((event) => event.verb)).toEqual(['status_changed', 'create']);
+  });
+});
+
+describe('parseEventsResponse', () => {
+  it('normalizes snake_case event fields', () => {
+    const events = parseEventsResponse({
+      events: [
+        {
+          id: 1,
+          created_at: '2026-02-19T17:46:30+00:00',
+          author: 'Liz Ayers',
+          verb: 'published',
+          description: 'Liz Ayers included a product on Online Store: Product.'
+        }
+      ]
+    });
+
+    expect(events[0]?.created_at).toBe('2026-02-19T17:46:30+00:00');
+    expect(events[0]?.author).toBe('Liz Ayers');
+  });
+
+  it('normalizes camelCase createdAt from the payload', () => {
+    const events = parseEventsResponse({
+      events: [
+        {
+          id: 1,
+          createdAt: '2026-02-19T17:46:30+00:00',
+          author: 'Liz Ayers',
+          verb: 'published',
+          description: 'Liz Ayers included a product on Online Store: Product.'
+        }
+      ]
+    });
+
+    expect(events[0]?.created_at).toBe('2026-02-19T17:46:30+00:00');
+  });
+});
+
+describe('formatEventClockTime', () => {
+  it('formats a valid event timestamp as HH:MM:SS', () => {
+    const event = baseEvent({ created_at: '2026-02-19T10:40:57+00:00' });
+    expect(formatEventClockTime(event)).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+    expect(getEventTimestampMs(event)).not.toBeNull();
+  });
+
+  it('reads camelCase createdAt when created_at is missing', () => {
+    const event = {
+      author: 'Liz Ayers',
+      createdAt: '2026-02-19T17:46:30+00:00'
+    };
+
+    expect(formatEventClockTime(event)).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+});
+
+describe('groupEditEvents', () => {
+  it('preserves shopify event order for same-timestamp events', () => {
+    const grouped = groupEditEvents([
+      baseEvent({ id: 237571030811008, verb: 'create', created_at: '2025-09-05T13:18:52+01:00' }),
+      baseEvent({
+        id: 237571031400832,
+        verb: 'status_changed',
+        created_at: '2025-09-05T13:18:52+01:00',
+        description: 'Jenny Hopper changed product status from active to draft: Lanoguard Pro Cleaning Bundle.'
+      })
+    ]);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0].kind).toBe('single');
+    expect(grouped[1].kind).toBe('single');
+    if (grouped[0].kind === 'single' && grouped[1].kind === 'single') {
+      expect(grouped[0].event.verb).toBe('create');
+      expect(grouped[1].event.verb).toBe('status_changed');
+    }
+  });
+
+  it('groups same-timestamp market publish events', () => {
+    const grouped = groupEditEvents([
+      marketEvent('Eurozone', '2026-02-19T10:40:59+00:00', 1),
+      marketEvent('International', '2026-02-19T10:40:59+00:00', 2),
+      baseEvent({ id: 3, verb: 'create', created_at: '2026-02-19T10:40:57+00:00' })
+    ]);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0].kind).toBe('target-group');
+    if (grouped[0].kind === 'target-group') {
+      expect(grouped[0].targetKind).toBe('market');
+      expect(grouped[0].groupVerb).toBe('published');
+      expect(grouped[0].targets).toEqual(['Eurozone', 'International']);
+    }
+    expect(grouped[1].kind).toBe('single');
+  });
+
+  it('groups same-timestamp sales channel publish events', () => {
+    const grouped = groupEditEvents([
+      salesChannelEvent('Point of Sale', '2026-02-19T21:29:54+00:00', 1),
+      salesChannelEvent('Shop', '2026-02-19T21:29:54+00:00', 2),
+      salesChannelEvent('Buy Button', '2026-02-19T21:29:54+00:00', 3),
+      salesChannelEvent('Lanoguard UK New', '2026-02-19T21:29:54+00:00', 4),
+      salesChannelEvent('Application Centres [Metaobjects]', '2026-02-19T21:29:54+00:00', 5)
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].kind).toBe('target-group');
+    if (grouped[0].kind === 'target-group') {
+      expect(grouped[0].targetKind).toBe('sales-channel');
+      expect(grouped[0].groupVerb).toBe('published');
+      expect(grouped[0].targets).toEqual([
+        'Point of Sale',
+        'Shop',
+        'Buy Button',
+        'Lanoguard UK New',
+        'Application Centres [Metaobjects]'
+      ]);
+      expect(formatTargetList(grouped[0].targets, grouped[0].targetKind)).toBe(
+        'Point of Sale, Shop, Buy Button, Lanoguard UK New, Application Centres [Metaobjects]'
+      );
+    }
+  });
+
+  it('groups same-timestamp sales channel unpublish events', () => {
+    const grouped = groupEditEvents([
+      salesChannelUnpublishEvent('Microsoft Channel', '2026-02-19T21:29:57+00:00', 1),
+      salesChannelUnpublishEvent('TikTok', '2026-02-19T21:29:57+00:00', 2),
+      salesChannelUnpublishEvent('Inbox', '2026-02-19T21:29:57+00:00', 3),
+      salesChannelUnpublishEvent('Google & YouTube', '2026-02-19T21:29:57+00:00', 4)
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].kind).toBe('target-group');
+    if (grouped[0].kind === 'target-group') {
+      expect(grouped[0].groupVerb).toBe('unpublished');
+      expect(grouped[0].targetKind).toBe('sales-channel');
+      expect(grouped[0].targets).toEqual(['Microsoft Channel', 'TikTok', 'Inbox', 'Google & YouTube']);
+      expect(formatTargetGroupDescription(grouped[0].groupVerb, grouped[0].targetKind, grouped[0].targets)).toBe(
+        'Unpublished from Microsoft Channel, TikTok, Inbox, Google & YouTube sales channels'
+      );
+    }
+  });
+
+  it('keeps sales channel publish events with different timestamps separate', () => {
+    const grouped = groupEditEvents([
+      salesChannelEvent('Shop', '2026-02-19T21:29:54+00:00', 1),
+      salesChannelEvent('Buy Button', '2026-02-19T21:29:55+00:00', 2)
+    ]);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0].kind).toBe('single');
+    expect(grouped[1].kind).toBe('single');
+  });
+
+  it('keeps single market publish events ungrouped', () => {
+    const grouped = groupEditEvents([marketEvent('Eurozone', '2026-02-19T10:40:59+00:00', 1)]);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].kind).toBe('single');
+  });
+});
+
+describe('isSalesChannelUnpublishEvent', () => {
+  it('detects sales channel unpublish rows from description text', () => {
+    expect(isSalesChannelUnpublishEvent(salesChannelUnpublishEvent('TikTok', '2026-02-19T21:29:57+00:00', 1))).toBe(
+      true
+    );
+    expect(isSalesChannelUnpublishEvent(salesChannelEvent('Shop', '2026-02-19T21:29:54+00:00', 1))).toBe(false);
+  });
+});
+
+describe('extractSalesChannelUnpublishTarget', () => {
+  it('pulls the sales channel label without the product title suffix', () => {
+    expect(
+      extractSalesChannelUnpublishTarget(salesChannelUnpublishEvent('Google & YouTube', '2026-02-19T21:29:57+00:00', 1))
+    ).toBe('Google & YouTube');
+    expect(
+      extractSalesChannelUnpublishTarget(
+        salesChannelUnpublishEvent('Microsoft Channel', '2026-02-19T21:29:57+00:00', 2)
+      )
+    ).toBe('Microsoft Channel');
+  });
+});
+
+describe('isSalesChannelPublishEvent', () => {
+  it('detects sales channel publish rows from description text', () => {
+    expect(isSalesChannelPublishEvent(salesChannelEvent('Shop', '2026-02-19T21:29:54+00:00', 1))).toBe(true);
+    expect(isSalesChannelPublishEvent(marketEvent('Eurozone', '2026-02-19T10:40:59+00:00', 1))).toBe(false);
+  });
+});
+
+describe('extractSalesChannelName', () => {
+  it('pulls the sales channel label from the event description', () => {
+    expect(extractSalesChannelName(salesChannelEvent('Point of Sale', '2026-02-19T21:29:54+00:00', 1))).toBe(
+      'Point of Sale'
+    );
+  });
+});
+
+describe('isMarketPublishEvent', () => {
+  it('detects market publish rows from description text', () => {
+    expect(isMarketPublishEvent(marketEvent('Eurozone', '2026-02-19T10:40:59+00:00', 1))).toBe(true);
+    expect(isMarketPublishEvent(baseEvent({ verb: 'published', description: 'Product published.' }))).toBe(false);
+  });
+});
+
+describe('extractMarketName', () => {
+  it('pulls the market label from the event description', () => {
+    expect(extractMarketName(marketEvent('Eurozone', '2026-02-19T10:40:59+00:00', 1))).toBe('Eurozone');
+  });
+});
+
+describe('formatEventDescription', () => {
+  it('rewrites sales channel publish descriptions', () => {
+    expect(formatEventDescription('Liz Ayers included a product on Online Store: Lanoguard Pro Cleaning Bundle.')).toBe(
+      'Liz Ayers included the product on Online Store sales channel'
+    );
+  });
+
+  it('rewrites status change descriptions', () => {
+    expect(
+      formatEventDescription('Jenny Hopper changed product status from active to draft: Lanoguard Pro Cleaning Bundle.')
+    ).toBe('Jenny Hopper changed the product status from active to draft');
+  });
+
+  it('rewrites create descriptions', () => {
+    expect(formatEventDescription('Jenny Hopper created a new product: Lanoguard Pro Cleaning Bundle.')).toBe(
+      'Jenny Hopper created the product'
+    );
+  });
+
+  it('rewrites market publish descriptions', () => {
+    expect(formatEventDescription('Product was included on Eurozone: Summer Bundle.')).toBe(
+      'Included the product on Eurozone market'
+    );
+  });
+
+  it('replaces a product with the product in any message', () => {
+    expect(formatEventDescription('Liz Ayers unpublished a product: Lanoguard Pro Cleaning Bundle.')).toBe(
+      'Liz Ayers unpublished the product'
+    );
+    expect(formatEventDescription('Liz Ayers updated a product title: Lanoguard Pro Cleaning Bundle.')).toBe(
+      'Liz Ayers updated the product title'
+    );
+  });
+
+  it('rewrites sales channel unpublish descriptions', () => {
+    expect(formatEventDescription(`Liz Ayers excluded the product from TikTok: ${productSuffix}.`)).toBe(
+      'Liz Ayers excluded the product from TikTok sales channel'
+    );
+  });
+});
+
+describe('formatMarketList', () => {
+  it('groups repeated managed markets catalogs', () => {
+    expect(
+      formatMarketList([
+        'Managed Markets catalog for BL',
+        'Managed Markets catalog for BJ',
+        'Managed Markets catalog for BI'
+      ])
+    ).toBe('Managed Markets catalog (BL, BJ, BI)');
+  });
+
+  it('keeps unique market names unchanged', () => {
+    expect(formatMarketList(['Eurozone', 'International'])).toBe('Eurozone, International');
+  });
+
+  it('mixes standalone markets with grouped catalogs', () => {
+    expect(formatMarketList(['Eurozone', 'Managed Markets catalog for BL', 'Managed Markets catalog for BJ'])).toBe(
+      'Eurozone, Managed Markets catalog (BL, BJ)'
+    );
+  });
+});
+
+describe('isShopifyAuthor', () => {
+  it('detects Shopify system events', () => {
+    expect(isShopifyAuthor('Shopify')).toBe(true);
+    expect(isShopifyAuthor(' shopify ')).toBe(true);
+    expect(isShopifyAuthor('Jenny Hopper')).toBe(false);
+  });
+});
+
+describe('formatVerbLabel', () => {
+  it('formats known verbs', () => {
+    expect(formatVerbLabel('unpublished')).toBe('Unpublished');
+    expect(formatVerbLabel('status_changed')).toBe('Status changed');
+    expect(formatVerbLabel('create')).toBe('Created');
+  });
+
+  it('title-cases unknown snake_case verbs', () => {
+    expect(formatVerbLabel('some_custom_verb')).toBe('Some Custom Verb');
+  });
+});
+
+describe('getVerbBadgeClass', () => {
+  it('strips underscores for css class names', () => {
+    expect(getVerbBadgeClass('status_changed')).toBe('alfred-edit-history__badge--statuschanged');
+    expect(getVerbBadgeClass('unpublished')).toBe('alfred-edit-history__badge--unpublished');
+  });
+});
+
+describe('getEventDetail', () => {
+  it('returns changed fields for update events', () => {
+    expect(
+      getEventDetail(
+        baseEvent({
+          verb: 'update',
+          arguments: ['Product name', 'title', 'body_html', 'api_client_id', 1830279]
+        })
+      )
+    ).toBe('title, body_html');
+  });
+
+  it('returns null for non-update events', () => {
+    expect(getEventDetail(baseEvent({ verb: 'create' }))).toBeNull();
+  });
+});

--- a/global.d.ts
+++ b/global.d.ts
@@ -75,6 +75,7 @@ declare interface AlfredSettings {
     collapsibleSidebar?: boolean;
     warnBeforeClosingCodeEditor?: boolean;
     themeListUtils?: boolean;
+    editHistory?: boolean;
   };
 }
 

--- a/supabase/functions/track/index.ts
+++ b/supabase/functions/track/index.ts
@@ -93,7 +93,9 @@ const VALID_ACTIONS = [
   'robots_copy',
   'robots_open',
   'robots_ai_toggle',
-  'robots_wrap_toggle'
+  'robots_wrap_toggle',
+  'edit_history_expand',
+  'edit_history_view'
 ];
 
 serve(async (req) => {

--- a/utils/analytics-actions.ts
+++ b/utils/analytics-actions.ts
@@ -89,7 +89,9 @@ export const ANALYTICS_ACTIONS = [
   'robots_copy',
   'robots_open',
   'robots_ai_toggle',
-  'robots_wrap_toggle'
+  'robots_wrap_toggle',
+  'edit_history_expand',
+  'edit_history_view'
 ] as const;
 
 export type AnalyticsAction = (typeof ANALYTICS_ACTIONS)[number];
@@ -191,7 +193,9 @@ export const TIME_SAVINGS: Record<AnalyticsAction, number | ((metadata?: Record<
   robots_copy: 30,
   robots_open: 5,
   robots_ai_toggle: 5,
-  robots_wrap_toggle: 0
+  robots_wrap_toggle: 0,
+  edit_history_expand: 0,
+  edit_history_view: 30
 };
 
 /** Actions that are tracked to Supabase but excluded from local usage stats.
@@ -217,6 +221,8 @@ export const ACTION_CATEGORIES: Record<AnalyticsAction, string> = {
   open_image_in_admin: 'Admin Nav',
   open_section_in_code_editor: 'Admin Nav',
   toggle_admin_sidebar: 'Admin Nav',
+  edit_history_expand: 'Admin Nav',
+  edit_history_view: 'Admin Nav',
   copy_product_json: 'Copy Data',
   copy_cart_json: 'Copy Data',
   copy_theme_preview_url: 'Copy Data',


### PR DESCRIPTION
## Summary

Adds an **Activity log** to Shopify Admin product and page screens. Alfred injects a collapsible **Activity** card at the top of the right sidebar that loads `/events.json` on expand and renders Shopify's edit history in a readable format.

- **Toggle:** Alfred Options → Shopify Admin → **Activity log** (`admin.editHistory`, on by default)
- **Scope:** Product and page admin URLs on `admin.shopify.com` and legacy `/admin/...` paths
- **Lazy load:** Fetches events only when the panel is expanded; refetches on each expand
- **Trusted Types safe:** DOM is built with `createElement` / `textContent` (no `innerHTML`)

### Display

- Verb badges (Created, Updated, Published, Unpublished, Status changed, etc.)
- Relative time in the header (`9 months ago`) plus author + clock time in the footer (`Jenny Hopper • 17:46:30`)
- Product/page names stripped from descriptions to reduce repetition
- Shopify system events get a distinct background treatment
- Update events show changed fields from `arguments` (e.g. `title, body_html`)

### Grouping (same timestamp)

Bursts of related events at the same instant collapse into one card:

| Event type | Grouped output |
|---|---|
| Market publishes | `Published to Managed Markets catalog (BL, BJ, BI…)` |
| Sales channel publishes | `Published to Shop, Buy Button, Point of Sale sales channels` |
| Sales channel unpublishes | `Unpublished from TikTok, Google & YouTube, Inbox sales channels` |

Channel/market names are parsed before the `: Product title` suffix so product names never repeat in grouped rows.

### Ordering

Uses Shopify's API order with smart reversal only when the payload arrives oldest-first, preserving tie order for same-second events (e.g. create before status_changed).

## Files

- `edit-history.logic.ts` — parsing, formatting, grouping, timestamp normalization
- `edit-history.util.ts` — sidebar injection, DOM rendering, fetch lifecycle
- `edit-history.test.ts` — 37 unit tests
- Settings type/default, Admin settings UI, analytics actions + Supabase parity

## Test plan

- [ ] Reload extension on a product admin page → **Activity** card appears at top of right sidebar
- [ ] Expand Activity → events load; collapse and re-expand → refetches
- [ ] Same-timestamp sales channel publish/unpublish bursts show as single grouped rows
- [ ] Same-timestamp market publishes use compact Managed Markets formatting
- [ ] Author line shows `Name • HH:MM:SS` in local time
- [ ] Disable **Activity log** in settings → card removed after refresh
- [ ] `bun test entrypoints/shopify-admin.content/tests/edit-history.test.ts` passes (37 tests)


Made with [Cursor](https://cursor.com)